### PR TITLE
Feature/form improvements

### DIFF
--- a/classes/form.php
+++ b/classes/form.php
@@ -66,6 +66,21 @@ class Form extends Iterator
     }
 
     /**
+     * Get value of given variable (or all values).
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function setValue($name = null, $value = '')
+    {
+        if (!$name) {
+            return;
+        }
+
+        $this->values[$name] = $value;
+    }
+
+    /**
      * Reset values.
      */
     public function reset()

--- a/form.php
+++ b/form.php
@@ -119,6 +119,17 @@ class FormPlugin extends Plugin
         }
 
         switch ($action) {
+            case 'captcha':
+                //Validate the captcha
+                $url = 'https://www.google.com/recaptcha/api/siteverify?secret=';
+                $url .= $params['recatpcha_secret'];
+                $url .= '&response=' . $this->form->value('g-recaptcha-response');
+                $response = json_decode(file_get_contents($url), true);
+
+                if ($response['success'] == false) {
+                    throw new \RuntimeException('Error validating the Captcha');
+                }
+                break;
             case 'message':
                 $this->form->message = (string) $params;
                 break;

--- a/form.php
+++ b/form.php
@@ -163,7 +163,11 @@ class FormPlugin extends Plugin
                 $prefix = !empty($params['fileprefix']) ? $params['fileprefix'] : '';
                 $format = !empty($params['dateformat']) ? $params['dateformat'] : 'Ymd-His-u';
                 $ext = !empty($params['extension']) ? '.' . trim($params['extension'], '.') : '.txt';
-                $filename = $prefix . $this->udate($format) . $ext;
+                $filename = !empty($params['filename']) ? $params['filename'] : '';
+
+                if (!$filename) {
+                    $filename = $prefix . $this->udate($format) . $ext;
+                }
 
                 /** @var Twig $twig */
                 $twig = $this->grav['twig'];

--- a/form.php
+++ b/form.php
@@ -164,6 +164,7 @@ class FormPlugin extends Plugin
                 $format = !empty($params['dateformat']) ? $params['dateformat'] : 'Ymd-His-u';
                 $ext = !empty($params['extension']) ? '.' . trim($params['extension'], '.') : '.txt';
                 $filename = !empty($params['filename']) ? $params['filename'] : '';
+                $operation = !empty($params['operation']) ? $params['operation'] : 'create';
 
                 if (!$filename) {
                     $filename = $prefix . $this->udate($format) . $ext;

--- a/form.php
+++ b/form.php
@@ -119,6 +119,8 @@ class FormPlugin extends Plugin
             return;
         }
 
+        $this->process($form);
+
         switch ($action) {
             case 'captcha':
                 //Validate the captcha
@@ -229,6 +231,26 @@ class FormPlugin extends Plugin
         }
 
         return true;
+    }
+
+    /**
+     * Process a form
+     *
+     * Currently available processing tasks:
+     *
+     * - fillWithCurrentDateTime
+     *
+     * @param Form $form
+     * @return bool
+     */
+    protected function process($form) {
+        foreach ($form->fields as $field) {
+            if (isset($field['process'])) {
+                if (isset($field['process']['fillWithCurrentDateTime']) && $field['process']['fillWithCurrentDateTime']) {
+                    $form->setValue($field['name'], gmdate('D, d M Y H:i:s', time()));
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Introduce 

- Server-side captcha validation
- Allow to specify a `filename` instead of `prefix`, `format` and `extension`
- Add a `operation` param to allow specify different file saving strategies
- Implement the 'add' file saving strategy: adds to a file (creating it if not existing) instead of creating a file for each form submission
- Implement and call a process() method during the form processing. Allows field to call possibly common processing functionality. First added: fillWithCurrentDateTime