### PR TITLE
Fix radio inputs

### DIFF
--- a/templates/forms/fields/checkboxes/checkboxes.html.twig
+++ b/templates/forms/fields/checkboxes/checkboxes.html.twig
@@ -15,7 +15,7 @@
 {% block input %}
     {% for key, text in field.options %}
 
-        {% set id = field.name ~ '-' ~ key %}
+        {% set id = field.id|default(field.name) ~ '-' ~ key %}
         {% set name = field.use == 'keys' ? key : id %}
         {% set val = field.use == 'keys' ? '1' : key %}
         {% set checked = (field.use == 'keys' ? value[key] : key in value) %}

--- a/templates/forms/fields/radio/radio.html.twig
+++ b/templates/forms/fields/radio/radio.html.twig
@@ -2,28 +2,16 @@
 
 {% set originalValue = value %}
 {% set value = (value is null ? field.default : value) %}
-{% if field.use == 'keys' and field.default %}
-    {% set value = field.default|merge(value) %}
-{% endif %}
-
-{% block global_attributes %}
-    {{ parent() }}
-    data-grav-keys="{{ field.use == 'keys' ? 'true' : 'false' }}"
-    data-grav-field-name="{{ field.name|fieldName }}"
-{% endblock %}
 
 {% block input %}
     {% for key, text in field.options %}
-        {% set id = "radio_" ~ field.name ~ key %}
-        {% set name = field.use == 'keys' ? key : id %}
-        {% set val = field.use == 'keys' ? '1' : key %}
-        {% set checked = (field.use == 'keys' ? value[key] : key in value) %}
+        {% set id = field.id|default(field.name) ~ '-' ~ key %}
 
         <span class="radio">
             <input type="radio"
-                   value="{{ val|e }}"
+                   value="{{ key|e }}"
                    id="{{ id|e }}"
-                   name="{{ field.name|fieldName ~ '[' ~ name ~ ']' }}"
+                   name="{{ field.name|fieldName }}"
                    {% if key == value %}checked="checked" {% endif %}
                    {% if field.validate.required in ['on', 'true', 1] %}required="required"{% endif %}
             />


### PR DESCRIPTION
At the moment each radio box gets its own unique name. This way, the radio boxes aren't grouped and toggle mechanism does not work.

In addition, the patch harmonizes ID naming among checkboxes and radio boxes.