### PR TITLE
Support for cols,rows and size attribute, default type is text and label can be ommited

### DIFF
--- a/templates/forms/default/form.html.twig
+++ b/templates/forms/default/form.html.twig
@@ -6,7 +6,7 @@
 {% for field in form.fields %}
     {% set value = form.value(field.name) %}
     <div>
-        {% include "forms/fields/#{field.type}/#{field.type}.html.twig" %}
+        {% include "forms/fields/#{field.type|default('text')}/#{field.type|default('text')}.html.twig" %}
     </div>
 {% endfor %}
 

--- a/templates/forms/field.html.twig
+++ b/templates/forms/field.html.twig
@@ -43,6 +43,7 @@
                                     {% if field.novalidate in ['on', 'true', 1] %}novalidate="novalidate"{% endif %}
                                     {% if field.readonly in ['on', 'true', 1] %}readonly="readonly"{% endif %}
                                     {% if field.autocomplete in ['on', 'off'] %}autocomplete="{{ field.autocomplete }}"{% endif %}
+                                    {% if field.size %}size="{{ field.size }}"{% endif %}
                                     {% if field.validate.required in ['on', 'true', 1] %}required="required"{% endif %}
                                     {% if field.validate.pattern %}pattern="{{ field.validate.pattern }}"{% endif %}
                                     {% if field.validate.message %}title="{{ field.validate.message|e|t }}"

--- a/templates/forms/field.html.twig
+++ b/templates/forms/field.html.twig
@@ -10,9 +10,9 @@
                 <label class="inline">
                 {% block label %}
                     {% if field.help %}
-                    <span class="tooltip" data-asTooltip-position="w" title="{{ field.help|e }}">{{ field.label }}</span>
+                    <span class="tooltip" data-asTooltip-position="w" title="{{ field.help|e }}">{{ field.label|default(field.name|capitalize) }}</span>
                     {% else %}
-                    {{ field.label }}
+                    {{ field.label|default(field.name|capitalize) }}
                     {% endif %}
                     {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}
                 {% endblock %}

--- a/templates/forms/fields/textarea/textarea.html.twig
+++ b/templates/forms/fields/textarea/textarea.html.twig
@@ -19,6 +19,8 @@
                 {% if field.validate.required in ['on', 'true', 1] %}required="required"{% endif %}
                 {% if field.validate.pattern %}pattern="{{ field.validate.pattern }}"{% endif %}
                 {% if field.validate.message %}title="{% if grav.twig.twig.filters['tu'] is defined %}{{ field.validate.message|tu }}{% else %}{{ field.validate.message|t }}{% endif %}"{% endif %}
+                {% if field.rows is defined %}rows="{{ field.rows }}"{% endif %}
+                {% if field.cols is defined %}cols="{{ field.cols }}"{% endif %}
             {% endblock %}
             >{{ value|trim|e('html') }}</textarea>
     </div>

--- a/templates/forms/fields/textarea/textarea.html.twig
+++ b/templates/forms/fields/textarea/textarea.html.twig
@@ -2,7 +2,7 @@
 
 {% block input %}
     <div class="form-textarea-wrapper {{ field.size }}">
-        <textarea class="input" name="{{ (scope ~ field.name)|fieldName }}"
+        <textarea class="input"
             {# required attribute structures #}
             name="{{ (scope ~ field.name)|fieldName }}"
             {# input attribute structures #}


### PR DESCRIPTION
I added a few small additions to the form plugin which may be useful for others:
- Added support for the `size` attribute of input fields
- Added support of the `rows` and `cols` attribute of textfields
- Made the text field the default type so the the type field can be ommitted in the form declaration
- Added the option to omit the label declaration. The label then defaults to the field name with the first letter in upper case (eg field name `address` becomes label `Address`)

This makes form declarations more concise as `type: text` and most trivial labels can be omitted.

