### PR TITLE
Make checkboxes label translateable

### DIFF
--- a/templates/forms/fields/checkboxes/checkboxes.html.twig
+++ b/templates/forms/fields/checkboxes/checkboxes.html.twig
@@ -28,7 +28,7 @@
                    {% if checked %}checked="checked"{% endif %}
                    {% if field.validate.required %}required="required"{% endif %}
             >
-            <label style="display: inline" for="{{ id|e }}">{{ text|e }}</label>
+            <label style="display: inline" for="{{ id|e }}">{{ text|t|e }}</label>
         </span>
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
This PR enables to translate checkboxes label for different languages using eg.

```yaml
checkbox:
  type: checkboxes
  label: PLUGIN.CHECKBOXES_LABEL
  default:
    key: true
  options:
    key: PLUGIN.CHECKBOXES_KEY_LABEL
  use: keys
```