### PR TITLE
Correctly merge the file field configuration

### DIFF
--- a/classes/form.php
+++ b/classes/form.php
@@ -214,11 +214,12 @@ class Form extends Iterator
     {
         $config  = self::getGrav()['config'];
         $default = $config->get('plugins.form.files');
-        $settings = isset($this->items['fields'][$key]['files']) ? $this->items['fields'][$key]['files'] : [];
+        $settings = isset($this->items['fields'][$key]) ? $this->items['fields'][$key] : [];
 
         /** @var Page $page */
-        $page             = null;
-        $blueprint        = array_merge_recursive($default, $settings);
+        $page = null;
+        $blueprint = array_replace($default, $settings);
+
         $cleanFiles[$key] = [];
         if (!isset($blueprint)) {
             return false;
@@ -254,14 +255,8 @@ class Form extends Iterator
                 }
 
                 if (move_uploaded_file($tmp_name, "$destination/$name")) {
-                    $path                    = $page ? self::getGrav()['uri']->convertUrl($page, $page->route() . '/' . $name) : $destination . '/' . $name;
-                    $cleanFiles[$key][$path] = [
-                        'name'  => $file['name'][$index],
-                        'type'  => $file['type'][$index],
-                        'size'  => $file['size'][$index],
-                        'file'  => $destination . '/' . $name,
-                        'route' => $page ? $path : null
-                    ];
+                    $path = $page ? self::getGrav()['uri']->convertUrl($page, $page->route() . '/' . $name) : $destination . '/' . $name;
+                    $cleanFiles[$key][] = $path;
                 } else {
                     throw new \RuntimeException("Unable to upload file(s) to $destination/$name");
                 }

--- a/classes/form.php
+++ b/classes/form.php
@@ -255,8 +255,14 @@ class Form extends Iterator
                 }
 
                 if (move_uploaded_file($tmp_name, "$destination/$name")) {
-                    $path = $page ? self::getGrav()['uri']->convertUrl($page, $page->route() . '/' . $name) : $destination . '/' . $name;
-                    $cleanFiles[$key][] = $path;
+                    $path                    = $page ? self::getGrav()['uri']->convertUrl($page, $page->route() . '/' . $name) : $destination . '/' . $name;
+                    $cleanFiles[$key][$path] = [
+                        'name'  => $file['name'][$index],
+                        'type'  => $file['type'][$index],
+                        'size'  => $file['size'][$index],
+                        'file'  => $destination . '/' . $name,
+                        'route' => $page ? $path : null
+                    ];
                 } else {
                     throw new \RuntimeException("Unable to upload file(s) to $destination/$name");
                 }


### PR DESCRIPTION
Currently it picks the settings in the wrong way, and even after fixing
it, it merges the config (adding multiple and destination as arrays, so
the code following will break as it assumes those are strings). The new
code replaces the default values with the array values set in the field.