### PR TITLE
Move recaptcha keys configuration from per-page config data to shared…

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -64,9 +64,9 @@ form:
           type: text
           label: PLUGIN_FORM.RECAPTCHA_SITE_KEY
           help: PLUGIN_FORM.RECAPTCHA_SITE_KEY_HELP
-          default: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
+          default: ''
         recaptcha.secret_key:
           type: text
           label: PLUGIN_FORM.RECAPTCHA_SECRET_KEY
           help: PLUGIN_FORM.RECAPTCHA_SECRET_KEY_HELP
-          default: '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
+          default: ''

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -55,3 +55,18 @@ form:
             - image/*
           validate:
               type: commalist
+    recaptcha:
+      type: section
+      title: PLUGIN_FORM.RECAPTCHA
+
+      fields:
+        recaptcha.site_key:
+          type: text
+          label: PLUGIN_FORM.RECAPTCHA_SITE_KEY
+          help: PLUGIN_FORM.RECAPTCHA_SITE_KEY_HELP
+          default: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
+        recaptcha.secret_key:
+          type: text
+          label: PLUGIN_FORM.RECAPTCHA_SECRET_KEY
+          help: PLUGIN_FORM.RECAPTCHA_SECRET_KEY_HELP
+          default: '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'

--- a/form.php
+++ b/form.php
@@ -98,8 +98,9 @@ class FormPlugin extends Plugin
             case 'captcha':
                 // Validate the captcha
                 $secret = $params['recatpcha_secret'];
-                if (empty($secret))
+                if (empty($secret)) {
                     $secret = $this->config->get('plugins.form.recaptcha.secret');
+                }
                 $query = http_build_query([
                     'secret' => $secret,
                     'response' => $this->form->value('g-recaptcha-response')

--- a/form.php
+++ b/form.php
@@ -97,8 +97,11 @@ class FormPlugin extends Plugin
         switch ($action) {
             case 'captcha':
                 // Validate the captcha
+                $secret = $params['recatpcha_secret'];
+                if (empty($secret))
+                    $secret = $this->config->get('plugins.form.recaptcha.secret');
                 $query = http_build_query([
-                    'secret' => $this->config->get('plugins.form.recaptcha.secret'),
+                    'secret' => $secret,
                     'response' => $this->form->value('g-recaptcha-response')
                 ]);
                 $url = 'https://www.google.com/recaptcha/api/siteverify?'.$query;

--- a/form.php
+++ b/form.php
@@ -98,7 +98,7 @@ class FormPlugin extends Plugin
             case 'captcha':
                 // Validate the captcha
                 $query = http_build_query([
-                    'secret' => $params['recatpcha_secret'],
+                    'secret' => $this->config->get('plugins.form.recaptcha.secret'),
                     'response' => $this->form->value('g-recaptcha-response')
                 ]);
                 $url = 'https://www.google.com/recaptcha/api/siteverify?'.$query;

--- a/languages.yaml
+++ b/languages.yaml
@@ -18,8 +18,21 @@ en:
 
 es:
   PLUGIN_FORM:
-    NOT_VALIDATED: "Falló la validación del formulario. Uno o más campos obligatorios no fueron capturados."
-    NONCE_NOT_VALIDATED: "Oops, hay un problema, por favor revice la información capturada e intente enviar el formulario otra vez."
+    NOT_VALIDATED: "Falló la validación del formulario. Uno o más campos obligatorios no fueron cubiertos."
+    NONCE_NOT_VALIDATED: "Oops, hay un problema, por favor revise la información e intente enviar el formulario otra vez."
+    FILES: "Subida de Ficheros"
+    ALLOW_MULTIPLE: "Permitir más de un fichero"
+    ALLOW_MULTIPLE_HELP: "Permitir seleccionar más de un fichero para subir."
+    DESTINATION: "Destino"
+    DESTINATION_HELP: "El lugar de destino al que subir los ficheros"
+    ACCEPT: "MIME Types permitidos"
+    ACCEPT_HELP: "Una lista de  MIME Types que se permiten subir."
+    ERROR_VALIDATING_CAPTCHA: "Error al comrobar el Captcha"
+    RECAPTCHA: "ReCaptcha"
+    RECAPTCHA_SITE_KEY: "Site key"
+    RECAPTCHA_SITE_KEY_HELP: "Para más información visita https://developers.google.com/recaptcha/intro"
+    RECAPTCHA_SECRET_KEY: "Secret key"
+    RECAPTCHA_SECRET_KEY_HELP: "Para más información visita https://developers.google.com/recaptcha/intro"
 
 fr:
   PLUGIN_FORM:

--- a/languages.yaml
+++ b/languages.yaml
@@ -10,6 +10,11 @@ en:
     ACCEPT: "Allowed MIME Types"
     ACCEPT_HELP: "A list of MIME Types that are allowed for upload"
     ERROR_VALIDATING_CAPTCHA: "Error validating the Captcha"
+    RECAPTCHA: "ReCaptcha"
+    RECAPTCHA_SITE_KEY: "Site key"
+    RECAPTCHA_SITE_KEY_HELP: "For more info visit https://developers.google.com/recaptcha/intro"
+    RECAPTCHA_SECRET_KEY: "Secret key"
+    RECAPTCHA_SECRET_KEY_HELP: "For more info visit https://developers.google.com/recaptcha/intro"
 
 es:
   PLUGIN_FORM:

--- a/templates/forms/fields/captcha/captcha.html.twig
+++ b/templates/forms/fields/captcha/captcha.html.twig
@@ -8,7 +8,7 @@
     <script>
         var captchaOnloadCallback = function captchaOnloadCallback() {
             grecaptcha.render('g-recaptcha', {
-                'sitekey': "{{field.recatpcha_site_key}}",
+                'sitekey': "{{ config.plugins.form.recaptcha.site_key }}",
                 'callback': captchaValidatedCallback,
                 'expired-callback': captchaExpiredCallback
             });

--- a/templates/forms/fields/captcha/captcha.html.twig
+++ b/templates/forms/fields/captcha/captcha.html.twig
@@ -5,10 +5,15 @@
         async defer>
     </script>
 
+    {% set site_key = field.recatpcha_site_key %}
+    {% if site_key is empty %}
+        {% set site_key = config.plugins.form.recaptcha.site_key %}
+    {% endif %}
+    
     <script>
         var captchaOnloadCallback = function captchaOnloadCallback() {
             grecaptcha.render('g-recaptcha', {
-                'sitekey': "{{ config.plugins.form.recaptcha.site_key }}",
+                'sitekey': "{{ site_key }}",
                 'callback': captchaValidatedCallback,
                 'expired-callback': captchaExpiredCallback
             });


### PR DESCRIPTION
… plugin config data.

When using recaptcha fileds in more than one form its better to share the api keys in the plugin config than repeating them in each form.md page file.