### PR TITLE
Fix type in readme : replace forms/forms.yaml by form/form.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ bin/gpm install form
 
 # Configuration
 
-Simply copy the `user/plugins/forms/forms.yaml` into `user/config/plugins/forms.yaml` and make your modifications.
+Simply copy the `user/plugins/form/form.yaml` into `user/config/plugins/form.yaml` and make your modifications.
 
 ```
 enabled: true
@@ -20,8 +20,8 @@ enabled: true
 
 # How to use the Form Plugin
 
-The Learn site has two pages describing how to use the Form Plugin: 
-- [Forms](http://learn.getgrav.org/advanced/forms) 
+The Learn site has two pages describing how to use the Form Plugin:
+- [Forms](http://learn.getgrav.org/advanced/forms)
 - [Add a contact form](http://learn.getgrav.org/advanced/contact-form)
 
 # Using email


### PR DESCRIPTION
There was a typo in the readme. I have replaced forms/forms.yaml by form/form.yaml