### PR TITLE
fixed capitlisation on form class link

### DIFF
--- a/form.php
+++ b/form.php
@@ -50,7 +50,7 @@ class FormPlugin extends Plugin
             $this->active = true;
 
             // Create form.
-            require_once(__DIR__ . '/classes/Form.php');
+            require_once(__DIR__ . '/classes/form.php');
             $this->form = new Form($page);
 
             $this->enable([


### PR DESCRIPTION
Pages containing forms were failing. Changing the capitalisation for the file link fixed it. 