### PR TITLE
Create color.html.twig

### DIFF
--- a/templates/forms/fields/color/color.html.twig
+++ b/templates/forms/fields/color/color.html.twig
@@ -1,0 +1,6 @@
+{% extends "forms/field.html.twig" %}
+
+{% block input_attributes %}
+    type="color" style="height: 2.663rem;"
+    {{ parent() }}
+{% endblock %}

--- a/templates/forms/fields/color/color.html.twig
+++ b/templates/forms/fields/color/color.html.twig
@@ -1,6 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
 {% block input_attributes %}
-    type="color" style="height: 2.663rem;"
+    type="color"
     {{ parent() }}
 {% endblock %}


### PR DESCRIPTION
Extends input types with color.

NOTE: 
Input type `color` needs a height eg `height: 2.663rem;` (equal to other inputs). 
Works with inline - but preferred to be set in admin plugins `_forms.scss` for all similar inputs.

@flaviocopes spoke about this, it is certainly a theme thing. 