### PR TITLE
Remove the <div> wrapping with no attributes

### DIFF
--- a/templates/forms/default/form.html.twig
+++ b/templates/forms/default/form.html.twig
@@ -23,9 +23,7 @@
 
 {% for field in form.fields %}
     {% set value = form.value(field.name) %}
-    <div>
         {% include "forms/fields/#{field.type}/#{field.type}.html.twig" %}
-    </div>
 {% endfor %}
 
 	<div class="buttons">


### PR DESCRIPTION
This wrapping div is in a perspective very pointless. As the child output is a wrapping div - with proper attributes. The un-attributed parent makes it not best for styling, and a form is never nice to style when it is clogged. 

And from the yaml perspective, the `outerclasses` is applied to the child wrapping, so all I can ask is why wrapping two times?