### PR TITLE
Callback must be defined before reCAPTCHA loads

### DIFF
--- a/templates/forms/fields/captcha/captcha.html.twig
+++ b/templates/forms/fields/captcha/captcha.html.twig
@@ -1,10 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
 {% block input %}
-    <script src="https://www.google.com/recaptcha/api.js?onload=captchaOnloadCallback&render=explicit"
-        async defer>
-    </script>
-
     <script>
         var captchaOnloadCallback = function captchaOnloadCallback() {
             grecaptcha.render('g-recaptcha', {
@@ -22,6 +18,8 @@
             grecaptcha.reset();
         };
     </script>
-
+    <script src="https://www.google.com/recaptcha/api.js?onload=captchaOnloadCallback&render=explicit"
+        async defer>
+    </script>
     <div class="g-recaptcha" id="g-recaptcha"></div>
 {% endblock %}


### PR DESCRIPTION
As the widget is explicitly rendered, onload callback function must be defined before the reCAPTCHA API loads.
To ensure there are no race conditions:
- order your scripts with the callback first, and then reCAPTCHA  

(Documented here: https://developers.google.com/recaptcha/docs/display)

Not sure if this is the case for everybody, it worked for me with a Bootstrap Theme.