### PR TITLE
Update to support attribute `for="id"` on label for checkbox

### DIFF
--- a/templates/forms/fields/checkbox/checkbox.html.twig
+++ b/templates/forms/fields/checkbox/checkbox.html.twig
@@ -24,6 +24,6 @@
             {% endblock %}
             />
 
-        <label class="inline">{{ field.label|e|t }} {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}</label>
+        <label class="inline"{% if field.id is defined %} for="{{ field.id|e }}"{% endif %}>{{ field.label|e|t }} {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}</label>
     </div>
 {% endblock %}


### PR DESCRIPTION
As the label is disabled to render before the input on type checkbox and instead add the custom label after, [this previous merged PR](https://github.com/getgrav/grav-plugin-form/commit/e000483a30895b4b1da1266fda7cdd5fc572cdda) will not add the attribute, till now. 

Also relates to earlier issue regarding best practise to achieve the attribute. 
Read [this link](https://github.com/getgrav/grav-plugin-form/issues/56)

Anyhow, the added code will improve ^^