### PR TITLE
Add scope to form data

### DIFF
--- a/form.php
+++ b/form.php
@@ -32,10 +32,10 @@ class FormPlugin extends Plugin
     public static function getSubscribedEvents()
     {
         return [
-            'onPageInitialized' => ['onPageInitialized', 0],
+            'onPageInitialized'   => ['onPageInitialized', 0],
             'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
             'onTwigSiteVariables' => ['onTwigSiteVariables', 0],
-            'onFormFieldTypes' => ['onFormFieldTypes', 0]
+            'onFormFieldTypes'    => ['onFormFieldTypes', 0]
         ];
     }
 

--- a/form.php
+++ b/form.php
@@ -275,7 +275,7 @@ class FormPlugin extends Plugin
         foreach ($form->fields as $field) {
             if (isset($field['process'])) {
                 if (isset($field['process']['fillWithCurrentDateTime']) && $field['process']['fillWithCurrentDateTime']) {
-                    $form->setValue($field['name'], gmdate('D, d M Y H:i:s', time()));
+                    $form->setData($field['name'], gmdate('D, d M Y H:i:s', time()));
                 }
             }
         }

--- a/form.php
+++ b/form.php
@@ -59,7 +59,7 @@ class FormPlugin extends Plugin
             $this->form = new Form($page);
 
             $this->enable([
-                'onFormProcessed' => ['onFormProcessed', 0],
+                'onFormProcessed'       => ['onFormProcessed', 0],
                 'onFormValidationError' => ['onFormValidationError', 0]
             ]);
 
@@ -107,15 +107,20 @@ class FormPlugin extends Plugin
             case 'captcha':
                 // Validate the captcha
                 $query = http_build_query([
-                    'secret' => isset($params['recaptcha_secret']) ? $params['recaptcha_secret'] : $params['recatpcha_secret'], //Allow value with typo for BC
+                    'secret'   => isset($params['recaptcha_secret']) ? $params['recaptcha_secret'] : $params['recatpcha_secret'],
+                    //Allow value with typo for BC
                     'response' => $this->form->value('g-recaptcha-response')
                 ]);
-                $url = 'https://www.google.com/recaptcha/api/siteverify?'.$query;
+                $url = 'https://www.google.com/recaptcha/api/siteverify?' . $query;
                 $response = json_decode(file_get_contents($url), true);
 
                 if (!isset($response['success']) || $response['success'] !== true) {
-                    $this->grav->fireEvent('onFormValidationError', new Event(['form' => $form, 'message' => $this->grav['language']->translate('PLUGIN_FORM.ERROR_VALIDATING_CAPTCHA')]));
+                    $this->grav->fireEvent('onFormValidationError', new Event([
+                        'form'    => $form,
+                        'message' => $this->grav['language']->translate('PLUGIN_FORM.ERROR_VALIDATING_CAPTCHA')
+                    ]));
                     $event->stopPropagation();
+
                     return;
                 }
                 break;
@@ -123,7 +128,7 @@ class FormPlugin extends Plugin
                 $this->form->message = $this->grav['language']->translate($params);
                 break;
             case 'redirect':
-                $this->grav->redirect((string) $params);
+                $this->grav->redirect((string)$params);
                 break;
             case 'reset':
                 if (Utils::isPositive($params)) {
@@ -131,7 +136,7 @@ class FormPlugin extends Plugin
                 }
                 break;
             case 'display':
-                $route = (string) $params;
+                $route = (string)$params;
                 if (!$route || $route[0] != '/') {
                     /** @var Uri $uri */
                     $uri = $this->grav['uri'];
@@ -166,9 +171,9 @@ class FormPlugin extends Plugin
 
                 /** @var Twig $twig */
                 $twig = $this->grav['twig'];
-                $vars = array(
+                $vars = [
                     'form' => $this->form
-                );
+                ];
 
                 $locator = $this->grav['locator'];
                 $path = $locator->findResource('user://data', true);
@@ -177,10 +182,8 @@ class FormPlugin extends Plugin
                 $file = File::instance($fullFileName);
 
                 if ($operation == 'create') {
-                    $body = $twig->processString(
-                        !empty($params['body']) ? $params['body'] : '{% include "forms/data.txt.twig" %}',
-                        $vars
-                    );
+                    $body = $twig->processString(!empty($params['body']) ? $params['body'] : '{% include "forms/data.txt.twig" %}',
+                        $vars);
                     $file->save($body);
                 } elseif ($operation == 'add') {
                     $vars = $vars['form']->value()->toArray();
@@ -211,7 +214,7 @@ class FormPlugin extends Plugin
     /**
      * Handle form validation error
      *
-     * @param  Event  $event An event object
+     * @param  Event $event An event object
      */
     public function onFormValidationError(Event $event)
     {
@@ -250,7 +253,7 @@ class FormPlugin extends Plugin
             'display' => [
                 'input@' => false
             ],
-            'spacer' => [
+            'spacer'  => [
                 'input@' => false
             ]
         ];
@@ -264,9 +267,11 @@ class FormPlugin extends Plugin
      * - fillWithCurrentDateTime
      *
      * @param Form $form
+     *
      * @return bool
      */
-    protected function process($form) {
+    protected function process($form)
+    {
         foreach ($form->fields as $field) {
             if (isset($field['process'])) {
                 if (isset($field['process']['fillWithCurrentDateTime']) && $field['process']['fillWithCurrentDateTime']) {
@@ -280,7 +285,8 @@ class FormPlugin extends Plugin
      * Create unix timestamp for storing the data into the filesystem.
      *
      * @param string $format
-     * @param int $utimestamp
+     * @param int    $utimestamp
+     *
      * @return string
      */
     private function udate($format = 'u', $utimestamp = null)

--- a/templates/form.html.twig
+++ b/templates/form.html.twig
@@ -1,0 +1,8 @@
+{% extends 'partials/base.html.twig' %}
+
+{% block content %}
+
+    {{ content }}
+    {% include "forms/form.html.twig" %}
+
+{% endblock %}

--- a/templates/formdata.html.twig
+++ b/templates/formdata.html.twig
@@ -1,0 +1,12 @@
+{% extends 'partials/base.html.twig' %}
+
+{% block content %}
+
+    {{ content }}
+
+    <div class="alert">{{ form.message }}</div>
+    <p>Here is the summary of what you wrote to us:</p>
+
+    {% include "forms/data.html.twig" %}
+
+{% endblock %}

--- a/templates/forms/default/data.html.twig
+++ b/templates/forms/default/data.html.twig
@@ -1,5 +1,8 @@
 {% for field in form.fields %}
-{% block field %}
-    <div>{% block field_label %}<strong>{{ field.label }}</strong>{% endblock %}: {% block field_value %}{{ string(form.value(field.name)|e)|nl2br }}{% endblock %}</div>
-{% endblock %}
+    {% set input = attribute(field, "input@") %}
+    {% if input is null or input == true %}
+        {% block field %}
+            <div>{% block field_label %}<strong>{{ field.label }}</strong>{% endblock %}: {% block field_value %}{{ string(form.value(field.name)|e)|nl2br }}{% endblock %}</div>
+        {% endblock %}
+    {% endif %}
 {% endfor %}

--- a/templates/forms/default/data.txt.twig
+++ b/templates/forms/default/data.txt.twig
@@ -1,4 +1,7 @@
 {% for field in form.fields %}
+{% set input = attribute(field, "input@") %}
+{% if input is null or input == true %}
 {% set value = form.value(field.name) %}
 {{ field.name }}: {{ string((value is iterable ? value|json_encode : value)|e|nl2br)|replace({"\n":' ', "\r":' '}) }}
+{% endif %}
 {% endfor %}

--- a/templates/forms/default/form.html.twig
+++ b/templates/forms/default/form.html.twig
@@ -1,4 +1,5 @@
 {% if form.message %}<div class="alert">{{ form.message }}</div>{% endif %}
+{% set scope = scope ?: 'data.' %}
 {% set multipart = '' %}
 {% set method = form.method|upper|default('POST') %}
 


### PR DESCRIPTION
This PR addresses the need to have some fields sent through the form, but not being part of the form data.

In particular the use case was the Captcha field, which should not be saved / visualized after being processed server-side.

The fields to be stored are now under the `data.*` scope. 

Adding `input@: false` to a field will make it being ignored in save / display actions.

Also, the PR adds the default page templates for form handling, causing less friction for users of themes that do not provide a form page template.

### Breaking change: 

In the form definition, if you are adding custom Twig processing for form values, the location `form.value.*` is now `form.value.data.*`, e.g. :

```
          email:
            body: '{% include "forms/data.html.twig" %}'
            from: '{{ form.value.email }}'
```

(sets the 'from' email value to the email entered in the form) is now:

```
          email:
            body: '{% include "forms/data.html.twig" %}'
            from: '{{ form.value.data.email }}'
```
