### PR TITLE
Allow text translations in `spacer` form fields

### DIFF
--- a/templates/forms/fields/spacer/spacer.html.twig
+++ b/templates/forms/fields/spacer/spacer.html.twig
@@ -1,10 +1,30 @@
 <div class="form-spacer">
     {% if field.title %}
-    <h3>{{ field.title|raw }}</h3>
+        <h3>
+            {% if grav.twig.twig.filters['tu'] is defined %}
+                {{- field.title|tu|raw -}}
+            {% else %}
+                {{- field.title|t|raw -}}
+            {% endif %}
+        </h3>
     {% endif %}
 
-    {% if field.text %}
-    <p>{{ field.text|raw }}</p>
+    {% if field.markdown %}
+        <p>
+            {% if grav.twig.twig.filters['tu'] is defined %}
+                {{- field.text|tu|markdown|raw -}}
+            {% else %}
+                {{- field.text|t|markdown|raw -}}
+            {% endif %}
+        </p>
+    {% else %}
+        <p>
+            {% if grav.twig.twig.filters['tu'] is defined %}
+                {{- field.text|tu|raw -}}
+            {% else %}
+                {{- field.text|t|raw -}}
+            {% endif %}
+        </p>
     {% endif %}
 
     {% if field.underline %}


### PR DESCRIPTION
This PR allows text inside `spacer` to be translated according the current language settings by Grav or by the logged in use. It further adds the option to process markdown on the text, too.