### PR TITLE
Add optional evaluate to the hidden field

### DIFF
--- a/templates/forms/fields/hidden/hidden.html.twig
+++ b/templates/forms/fields/hidden/hidden.html.twig
@@ -1,3 +1,3 @@
-{% set value = (value is null ? field.default : value) %}
+{% set value = (value is null ? (field.evaluate ? evaluate(field.default) : field.default) : value) %}
 
 <input data-grav-field="hidden" data-grav-disabled="false" type="hidden" class="input" name="{{ (scope ~ field.name)|fieldName }}" value="{{ value|join(', ') }}" />


### PR DESCRIPTION
Allow to process twig, for example to add a custom value
```
xxxxxx:
  type: hidden
  default: "random()"
  evaluate: true
  validate:
    type: string
```