### PR TITLE
Set hints for checkboxes options and allow field descriptions

### DIFF
--- a/templates/forms/default/field.html.twig
+++ b/templates/forms/default/field.html.twig
@@ -56,7 +56,7 @@
                 {% endblock %}
                 {% if field.description %}
                     <div class="form-extra-wrapper {{ field.size }} {{ field.wrapper_classes }}">
-                        <span class="form-description">{{ field.description }}</span>
+                        <span class="form-description">{{ field.description|raw }}</span>
                     </div>
                 {% endif %}
             </div>

--- a/templates/forms/default/field.html.twig
+++ b/templates/forms/default/field.html.twig
@@ -54,6 +54,11 @@
                         </div>
                     {% endblock %}
                 {% endblock %}
+                {% if field.description %}
+                    <div class="form-extra-wrapper {{ field.size }} {{ field.wrapper_classes }}">
+                        <span class="form-description">{{ field.description }}</span>
+                    </div>
+                {% endif %}
             </div>
         {% endblock %}
     </div>

--- a/templates/forms/fields/checkboxes/checkboxes.html.twig
+++ b/templates/forms/fields/checkboxes/checkboxes.html.twig
@@ -19,6 +19,7 @@
         {% set name = field.use == 'keys' ? key : id %}
         {% set val = field.use == 'keys' ? '1' : key %}
         {% set checked = (field.use == 'keys' ? value[key] : key in value) %}
+        {% set help = (key in field.help_options ? field.help_options[key] : false) %}
 
         <span class="checkboxes">
             <input type="checkbox"
@@ -29,7 +30,13 @@
                    {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}
                    {% if field.validate.required %}required="required"{% endif %}
             >
-            <label style="display: inline" for="{{ id|e }}">{{ text|t|e }}</label>
+            <label style="display: inline" for="{{ id|e }}">
+                {% if help %}
+                    <span class="hint--bottom" data-hint="{{ help|t|e('html_attr') }}">{{ text|t|e }}</span>
+                {% else %}
+                    {{ text|t|e }}
+                {% endif %}
+            </label>
         </span>
     {% endfor %}
 {% endblock %}

--- a/templates/forms/fields/checkboxes/checkboxes.html.twig
+++ b/templates/forms/fields/checkboxes/checkboxes.html.twig
@@ -19,7 +19,7 @@
         {% set name = field.use == 'keys' ? key : id %}
         {% set val = field.use == 'keys' ? '1' : key %}
         {% set checked = (field.use == 'keys' ? value[key] : key in value) %}
-        {% set help = (key in field.help_options ? field.help_options[key] : false) %}
+        {% set help = (key in field.help_options|keys ? field.help_options[key] : false) %}
 
         <span class="checkboxes">
             <input type="checkbox"


### PR DESCRIPTION
This PR is related to [#667](https://github.com/getgrav/grav-plugin-admin/pull/667), which adds a field description to forms and allows to show help hints for checkboxes items:

![hint](https://cloud.githubusercontent.com/assets/9073307/16131200/532e366a-340d-11e6-8b52-64ddf07935af.png)

**Usage:**

```yaml
mycheckboxes:
  type: checkboxes
  help_options:
    copyright: 'Here comes the help text for copyright checkbox'
    location: 'Here comes the help text for location checkbox'
  options:
    copyright: Copyright
    location: Location
```
