### PR TITLE
Fixed duplicate textarea class attribute

### DIFF
--- a/templates/forms/fields/textarea/textarea.html.twig
+++ b/templates/forms/fields/textarea/textarea.html.twig
@@ -3,13 +3,11 @@
 {% block input %}
     <div class="form-textarea-wrapper {{ field.size }}">
         <textarea
-            class="{{ field.classes|default('input') }}"
-
             {# required attribute structures #}
             name="{{ (scope ~ field.name)|fieldName }}"
             {# input attribute structures #}
             {% block input_attributes %}
-                {% if field.classes is defined %}class="{{ field.classes }}" {% endif %}
+                {% if field.classes is defined %}class="{{ field.classes }}" {% else %}class="{{ field.classes|default('input') }}" {% endif %}
                 {% if field.id is defined %}id="{{ field.id|e }}" {% endif %}
                 {% if field.style is defined %}style="{{ field.style|e }}" {% endif %}
                 {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}


### PR DESCRIPTION
When a user sets the `classes` attribute  for a `textarea` field, the Twig template duplicates the class attribute inside the textarea tag, resulting in a not valid HTML like this:

**Markdown source**
```markdown
- name: message
  classes: form-control
  type: textarea
```

**Final HTML**
```html
<div class="form-textarea-wrapper">
    <textarea class="form-control" name="data[message]" class="form-control"></textarea>
</div>
```