### PR TITLE
Allow form item replacement in redirect location

### DIFF
--- a/form.php
+++ b/form.php
@@ -343,7 +343,14 @@ class FormPlugin extends Plugin
                 break;
             case 'redirect':
                 $this->grav['session']->setFlashObject('form', $form);
-                $this->grav->redirect((string)$params);
+                $url = ((string)$params);
+                $vars = array(
+                    'form' => $form
+                );
+                /** @var Twig $twig */
+                $twig = $this->grav['twig'];
+                $url = $twig->processString($url, $vars);
+                $this->grav->redirect($url);
                 break;
             case 'reset':
                 if (Utils::isPositive($params)) {


### PR DESCRIPTION
I have a requirement in my grav setup to do replacement within a redirect.

The use case is this: I am requiring users to complete a simple form before downloading a PDF. Upon completion, the redirect goes to the PDF, using a hidden field in the form I'm populating from the querystring.