### PR TITLE
Bug fix for radio type form field

### DIFF
--- a/templates/forms/fields/radio/radio.html.twig
+++ b/templates/forms/fields/radio/radio.html.twig
@@ -16,7 +16,7 @@
                    {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}
                    {% if field.validate.required in ['on', 'true', 1] %}required="required"{% endif %}
             />
-            <label style="display: inline" class="inline" for="{{ id|e }}">{{ text|e }}</label>
+            <label style="display: inline" class="inline" for="{{ id|e }}">{% if grav.twig.twig.filters['tu'] is defined %}{{ text|tu|raw }}{% else %}{{ text|t|raw }}{% endif %}</label>
         </span>
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
The radio type wasn't properly getting a language value from a plugin so it was rendering as `PLUGIN.SQUIDGRID.SOMETHING` instead of the proper way. This fix proposes to put it in line with how the text is added in the select type which renders properly.