### PR TITLE
adds fix for #182

### DIFF
--- a/templates/forms/fields/captcha/captcha.html.twig
+++ b/templates/forms/fields/captcha/captcha.html.twig
@@ -19,7 +19,7 @@
         };
 
         $('form').submit(function(event) {
-            if ($("#g-recaptcha-response").val() === '') {
+            if ($(this).has("#g-recaptcha-response").length && $("#g-recaptcha-response").val() === '') {
                 event.preventDefault();
                 alert("{{grav.language.translate('PLUGIN_FORM.ERROR_VALIDATING_CAPTCHA')}}");
             }


### PR DESCRIPTION
Fix for #139 triggers an alert for other forms in the same page which doesn't contains a captcha filed.
E.g: search form. This commit fix this issue by checking if the submitted form has the captcha field before the validation.