### PR TITLE
Remembered fields feature

### DIFF
--- a/form.php
+++ b/form.php
@@ -372,6 +372,12 @@ class FormPlugin extends Plugin
                 unset($this->grav['page']);
                 $this->grav['page'] = $page;
                 break;
+            case 'remember':
+                foreach ($params as $remember_field) {
+                    $field_cookie = 'forms-'.$form['name'].'-'.$remember_field;
+                    setcookie($field_cookie, $form->value($remember_field),  time()+60*60*24*60);
+                }
+                break;
             case 'save':
                 $prefix = !empty($params['fileprefix']) ? $params['fileprefix'] : '';
                 $format = !empty($params['dateformat']) ? $params['dateformat'] : 'Ymd-His-u';
@@ -454,7 +460,7 @@ class FormPlugin extends Plugin
         // special check for honeypot field
         foreach ($event['form']->fields() as $field) {
             if ($field['type'] == 'honeypot' && !empty($event['form']->value($field['name']))) {
-                throw new ValidationException('Are you a bot?'); 
+                throw new ValidationException('Are you a bot?');
             }
         }
     }

--- a/templates/forms/default/field.html.twig
+++ b/templates/forms/default/field.html.twig
@@ -2,6 +2,8 @@
 {% set toggleableChecked = field.toggleable and (originalValue is not null and originalValue is not empty) %}
 {% set isDisabledToggleable = field.toggleable and not toggleableChecked %}
 {% set value = (is_object(value) or value is null ? field.default : value) %}
+{% set cookie_name = 'forms-' ~ form.name ~ '-' ~ field.name %}
+{% set value = (is_object(value) or value is null ? (get_cookie(cookie_name) is null ? field.default : get_cookie(cookie_name)) : value) %}
 {% set errors = attribute(form.messages, field.name) %}
 
 {% block field %}

--- a/templates/forms/default/field.html.twig
+++ b/templates/forms/default/field.html.twig
@@ -5,7 +5,7 @@
 {% set errors = attribute(form.messages, field.name) %}
 
 {% block field %}
-    <div class="form-field {% if field.outerclasses is defined %} {{ field.outerclasses }}{% endif %}{% if errors %} has-errors{% endif %} {% block outer_field_classes %}{% endblock %}">
+    <div class="form-field {% if field.outerclasses is defined %} {{ field.outerclasses }}{% endif %}{% if errors %} has-errors{% endif %} {% block outer_field_classes %}{% endblock %}" {%- block outer_field_attributes %}{% for dname,dval in field.data %} data-{{dname}}="{{ dval }}"{% endfor %}{% endblock %}>
         {% block contents %}
             {% if field.label is not same as(false) %}
                 <div class="form-label">

--- a/templates/forms/default/field.html.twig
+++ b/templates/forms/default/field.html.twig
@@ -5,7 +5,7 @@
 {% set errors = attribute(form.messages, field.name) %}
 
 {% block field %}
-    <div class="form-field {% if field.outerclasses is defined %} {{ field.outerclasses }}{% endif %}{% if errors %} has-errors{% endif %} {% block outer_field_classes %}{% endblock %}" {%- block outer_field_attributes %}{% for dname,dval in field.data-attributes %} data-{{dname}}="{{ dval }}"{% endfor %}{% endblock %}>
+    <div class="form-field {% if field.outerclasses is defined %} {{ field.outerclasses }}{% endif %}{% if errors %} has-errors{% endif %} {% block outer_field_classes %}{% endblock %}" {%- block outer_field_attributes %}{% for dname,dval in attribute(field, 'data-attributes') %} data-{{dname}}="{{ dval }}"{% endfor %}{% endblock %}>
         {% block contents %}
             {% if field.label is not same as(false) %}
                 <div class="form-label">

--- a/templates/forms/default/field.html.twig
+++ b/templates/forms/default/field.html.twig
@@ -5,7 +5,7 @@
 {% set errors = attribute(form.messages, field.name) %}
 
 {% block field %}
-    <div class="form-field {% if field.outerclasses is defined %} {{ field.outerclasses }}{% endif %}{% if errors %} has-errors{% endif %} {% block outer_field_classes %}{% endblock %}" {%- block outer_field_attributes %}{% for dname,dval in field.data %} data-{{dname}}="{{ dval }}"{% endfor %}{% endblock %}>
+    <div class="form-field {% if field.outerclasses is defined %} {{ field.outerclasses }}{% endif %}{% if errors %} has-errors{% endif %} {% block outer_field_classes %}{% endblock %}" {%- block outer_field_attributes %}{% for dname,dval in field.data-attributes %} data-{{dname}}="{{ dval }}"{% endfor %}{% endblock %}>
         {% block contents %}
             {% if field.label is not same as(false) %}
                 <div class="form-label">


### PR DESCRIPTION
I've used this simple hack successfully and it would certainly suit me to have it integrated.

The 'remember' processing instruction is useful in scenarios where a user is expected to repeatedly use a form and will want certain fields to be pre-populated with their values from last time. Obviously this is only appropriate in private user environments.

My use case was a medical referral form. Referring practitioners do not need to re-enter their own details each subsequent time they complete the form and can concentrate on patient details.

Here is the relevant form YAML:

```YAML
    - name: practitioner-name
        label: Practitioner name
        type: text
        hint: You will only need to complete this once per browser/device. It should be recalled subsequent occasions.
        validate:
            required: true

    - name: practitioner-address
        type: textarea
        label: Your address
        rows: 3
        placeholder: 'Your postal address for correspondence, including postcode'
        validate:
            required: true

    - name: practitioner-phone
        type: text
        label: Your phone
        validate:
            required: true

    - name: practitioner-email
        type: email
        label: Your email
        validate:
            required: true
```
and further down:

```yaml
    - remember:
        - practitioner-name
        - practitioner-address
        - practitioner-phone
        - practitioner-email
```

_There's an extraneous edited line where the honeypot code is that I couldn't eliminate, sorry about that_