### PR TITLE
textarea, maxlength and minlength attributes

### DIFF
--- a/templates/forms/fields/textarea/textarea.html.twig
+++ b/templates/forms/fields/textarea/textarea.html.twig
@@ -21,6 +21,8 @@
                 {% if field.validate.message %}title="{% if grav.twig.twig.filters['tu'] is defined %}{{ field.validate.message|tu|e }}{% else %}{{ field.validate.message|t|e }}{% endif %}"{% endif %}
                 {% if field.rows is defined %}rows="{{ field.rows }}"{% endif %}
                 {% if field.cols is defined %}cols="{{ field.cols }}"{% endif %}
+                {% if field.minlength is defined %}minlength="{{ field.minlength }}"{% endif %}
+                {% if field.maxlength is defined %}maxlength="{{ field.maxlength }}"{% endif %}
             {% endblock %}
             >{{ value|trim|e('html') }}</textarea>
     </div>


### PR DESCRIPTION
At the question of [@megalofauna](https://getgrav.slack.com/archives/C3Z7KN6MC/p1516882329000126) I gave this [answer](https://getgrav.slack.com/archives/C3Z7KN6MC/p1516885992000280).
In fact, the [@jgonyea](https://getgrav.slack.com/archives/C3Z7KN6MC/p1516886330000281) solution does not provide any changes to the code ... but the warning comes when you try to save the page.
I have made this PR if you think the solution is useful.