### PR TITLE
Replace `display:none` by `visibility:hidden`

### DIFF
--- a/templates/forms/fields/honeypot/honeypot.html.twig
+++ b/templates/forms/fields/honeypot/honeypot.html.twig
@@ -1,1 +1,5 @@
-<input type="text" style="display:none;" name="{{ (scope ~ field.name)|fieldName }}" value="{{ value|join(', ') }}" />
+<input aria-hidden="true"
+       type="text"
+       style="visibility:hidden;position:absolute!important;height:1px;width:1px;overflow:hidden;clip:rect(1px,1px,1px,1px);"
+       name="{{ (scope ~ field.name)|fieldName }}"
+       value="{{ value|join(', ') }}" />


### PR DESCRIPTION
... and a hiding content technique:

The inline CSS `display:none` is useless because "turns off the
display of an element so that it has no effect on layout (the document
is rendered as though the element did not exist)." - Source
<https://developer.mozilla.org/en-US/docs/Web/CSS/display#display-box>

So the spambot can't fill it too.

The honeypot input must not be visible by human nor screen reader but
it should be focusable by a bot.

So I combined `visibility:hidden`, `aria-hidden="true"` and the content of the `.visuallyhidden` helper class of HTML5 Boilerplate.