### PR TITLE
Added auto-rebuild form if internal cache fails

### DIFF
--- a/form.php
+++ b/form.php
@@ -84,6 +84,8 @@ class FormPlugin extends Plugin
      */
     public function onPageProcessed(Event $e)
     {
+        $this->grav['debugger']->addMessage('onPageProcessed');
+
         /** @var Page $page */
         $page = $e['page'];
         $page_route = $page->route();
@@ -126,6 +128,7 @@ class FormPlugin extends Plugin
      */
     public function onPagesInitialized()
     {
+        $this->grav['debugger']->addMessage('onPageSInitialized');
         $this->loadCachedForms();
     }
 
@@ -134,8 +137,18 @@ class FormPlugin extends Plugin
      */
     public function onPageInitialized()
     {
+        $this->grav['debugger']->addMessage('onPageInitialized');
+        $this->grav['debugger']->addMessage('$this->form: ');
+        $this->grav['debugger']->addMessage($this->form);
         $submitted = false;
         $this->json_response = [];
+
+        // Force rebuild form when form has not been built and form cache expired.
+        // This happens when form cache expires before the page cache
+        // and then does not trigger 'onPageProcessed' event.
+        if (!$this->forms) {
+            $this->onPageProcessed(new Event(['page' => $this->grav['page']]));
+        }
 
         // Save cached forms
         if ($this->recache_forms) {
@@ -707,8 +720,10 @@ class FormPlugin extends Plugin
      */
     protected function loadCachedForms()
     {
+
+        $this->grav['debugger']->addMessage('loadCachedForms');
         // Get and set the cache of forms if it exists
-        list($forms, $flat_forms) = $this->grav['cache']->fetch($this->getFormCacheId());
+        /*list($forms, $flat_forms) = $this->grav['cache']->fetch($this->getFormCacheId());
 
         // Only store the forms if they are an array
         if (is_array($forms)) {
@@ -718,7 +733,10 @@ class FormPlugin extends Plugin
         // Only store the flat_forms if they are an array
         if (is_array($flat_forms)) {
             $this->flat_forms = array_merge($this->flat_forms, $flat_forms);
-        }
+        }*/
+
+        //$this->grav['debugger']->addMessage('Cached $forms:');
+        //$this->grav['debugger']->addMessage($forms);
     }
 
     /**

--- a/form.php
+++ b/form.php
@@ -84,8 +84,6 @@ class FormPlugin extends Plugin
      */
     public function onPageProcessed(Event $e)
     {
-        $this->grav['debugger']->addMessage('onPageProcessed');
-
         /** @var Page $page */
         $page = $e['page'];
         $page_route = $page->route();
@@ -128,7 +126,6 @@ class FormPlugin extends Plugin
      */
     public function onPagesInitialized()
     {
-        $this->grav['debugger']->addMessage('onPageSInitialized');
         $this->loadCachedForms();
     }
 
@@ -137,9 +134,6 @@ class FormPlugin extends Plugin
      */
     public function onPageInitialized()
     {
-        $this->grav['debugger']->addMessage('onPageInitialized');
-        $this->grav['debugger']->addMessage('$this->form: ');
-        $this->grav['debugger']->addMessage($this->form);
         $submitted = false;
         $this->json_response = [];
 
@@ -720,10 +714,8 @@ class FormPlugin extends Plugin
      */
     protected function loadCachedForms()
     {
-
-        $this->grav['debugger']->addMessage('loadCachedForms');
         // Get and set the cache of forms if it exists
-        /*list($forms, $flat_forms) = $this->grav['cache']->fetch($this->getFormCacheId());
+        list($forms, $flat_forms) = $this->grav['cache']->fetch($this->getFormCacheId());
 
         // Only store the forms if they are an array
         if (is_array($forms)) {
@@ -733,10 +725,7 @@ class FormPlugin extends Plugin
         // Only store the flat_forms if they are an array
         if (is_array($flat_forms)) {
             $this->flat_forms = array_merge($this->flat_forms, $flat_forms);
-        }*/
-
-        //$this->grav['debugger']->addMessage('Cached $forms:');
-        //$this->grav['debugger']->addMessage($forms);
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request aim to add an auto form re-build process in the case of the internal form cache has been expired before the global pages grav cache.

Indeed if Grav hit the cache of the core Pages object, it will not trigger the `onPageProcessed` event (which is listen by the form plugin to build forms). So in this case, if the form cache expires before the Grav core Pages cache (yes it sometime happen, but I dont know why or when ^_^), then the form plugin (listing `onPageInitialized`) will get an empty form (because it was not built through the `onPageProcessed`) and an empty cache (because it was expired) and result to a completely broken form (no fields, no submit...).

I don't know if it's clear but this fix is in testing on my side in some live website and seems to correct the initial issue (forms sometime just disappears, and a manual clear cache solve the problem).

I can re-write this speech if it is not truly understandable (I am a french guy and know that my english speaking is not perfect ;) )