### PR TITLE
Fixed `Form::setFields()` causing validation to fail on added and removed fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v2.13.2
+## mm/dd/2018
+
+1. [](#new)
+    * Added event `onFormPrepareValidation` to allow some pre-processing before form validation
+1. [](#bugfix)
+    * Fixed `Form::setFields()` causing validation to fail on added and removed fields
+    
 # v2.13.1
 ## 03/21/2018
 

--- a/form.php
+++ b/form.php
@@ -1,10 +1,12 @@
 <?php
 namespace Grav\Plugin;
 
+use Composer\Autoload\ClassLoader;
 use Grav\Common\Data\ValidationException;
 use Grav\Common\Filesystem\Folder;
 use Grav\Common\Page\Page;
 use Grav\Common\Page\Pages;
+use Grav\Common\Page\Types;
 use Grav\Common\Plugin;
 use Grav\Common\Twig\Twig;
 use Grav\Common\Utils;
@@ -20,21 +22,24 @@ use RocketTheme\Toolbox\Event\Event;
  */
 class FormPlugin extends Plugin
 {
+    /** @var array */
     public $features = [
         'blueprints' => 1000
     ];
 
-    /**
-     * @var Form
-     */
+    /** @var Form */
     protected $form;
 
+    /** @var array */
     protected $forms = [];
 
+    /** @var array */
     protected $flat_forms = [];
 
+    /** @var array */
     protected $json_response = [];
 
+    /** @var bool */
     protected $recache_forms = false;
 
 
@@ -44,9 +49,22 @@ class FormPlugin extends Plugin
     public static function getSubscribedEvents()
     {
         return [
-            'onPluginsInitialized' => ['onPluginsInitialized', 0],
+            'onPluginsInitialized' => [
+                ['autoload', 100000],
+                ['onPluginsInitialized', 0]
+            ],
             'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0]
         ];
+    }
+
+    /**
+     * [onPluginsInitialized:100000] Composer autoload.
+     *
+     * @return ClassLoader
+     */
+    public function autoload()
+    {
+        return require __DIR__ . '/vendor/autoload.php';
     }
 
     /**
@@ -54,10 +72,8 @@ class FormPlugin extends Plugin
      */
     public function onPluginsInitialized()
     {
-        require_once __DIR__ . '/vendor/autoload.php';
-
         // Backwards compatibility for plugins that use forms.
-        class_alias('Grav\Plugin\Form\Form', 'Grav\Plugin\Form');
+        class_alias(Form::class, 'Grav\Plugin\Form');
 
         if ($this->isAdmin()) {
             $this->enable([
@@ -102,7 +118,7 @@ class FormPlugin extends Plugin
 
         $header = $page->header();
 
-        //call event to allow filling the page header form dynamically (e.g. use case: Comments plugin)
+        // Call event to allow filling the page header form dynamically (e.g. use case: Comments plugin)
         $this->grav->fireEvent('onFormPageHeaderProcessed', new Event(['page' => $page, 'header' => $header]));
 
         if ((isset($header->forms) && is_array($header->forms)) ||
@@ -160,9 +176,9 @@ class FormPlugin extends Plugin
         // Enable form events if there's a POST
         if ($this->shouldProcessForm()) {
             $this->enable([
-                'onFormProcessed' => ['onFormProcessed', 0],
+                'onFormProcessed'       => ['onFormProcessed', 0],
                 'onFormValidationError' => ['onFormValidationError', 0],
-                'onFormFieldTypes'       => ['onFormFieldTypes', 0],
+                'onFormFieldTypes'      => ['onFormFieldTypes', 0],
             ]);
 
             // Post the form
@@ -178,7 +194,7 @@ class FormPlugin extends Plugin
             // Clear flash objects for previously uploaded files
             // whenever the user switches page / reloads
             // ignoring any JSON / extension call
-            if (null === $this->grav['uri']->extension() && !$submitted) {
+            if (!$submitted && null === $this->grav['uri']->extension()) {
                 // Discard any previously uploaded files session.
                 // and if there were any uploaded file, remove them from the filesystem
                 if ($flash = $this->grav['session']->getFlashObject('files-upload')) {


### PR DESCRIPTION
Fixed `Form::setFields()` causing validation to fail on added and removed fields
Added event `onFormPrepareValidation` to allow some pre-processing before form validation
Some code cleanup, PHP 5.5 updates
