### PR TITLE
Added support for nesting id’s - fieldset testcase

### DIFF
--- a/templates/forms/default/data.html.twig
+++ b/templates/forms/default/data.html.twig
@@ -1,8 +1,10 @@
-{% macro render_field(form, fields) %}
+{% macro render_field(form, fields, scope) %}
     {% for index, field in fields %}
         {% set input = attribute(field, "input@") %}
+
         {% if input is null or input == true %}
-            {% if form.value(field.name) %}
+
+            {% if form.value(scope ~ field.name) %}
                 {% block field %}
                     <div>
                         {% block field_label %}
@@ -12,16 +14,16 @@
                         {% block field_value %}
                             {% if field.type == 'checkboxes' %}
                                 <ul>
-                                    {% for value in form.value(field.name) %}
+                                    {% for value in form.value(scope ~ field.name) %}
                                         <li>{{ field.options[value]|e }}</li>
                                     {% endfor %}
                                 </ul>
                             {% elseif field.type == 'checkbox' %}
-                                {{ (form.value(field.name) == 1) ? "PLUGIN_FORM.YES"|t|e : "PLUGIN_FORM.NO"|t|e }}
+                                {{ (form.value(scope ~ field.name) == 1) ? "PLUGIN_FORM.YES"|t|e : "PLUGIN_FORM.NO"|t|e }}
                             {% elseif field.type == 'select' %}
-                                {{ field.options[form.value(field.name)]|e }}
+                                {{ field.options[form.value(scope ~ field.name)]|e }}
                             {% else %}
-                                {{ string(form.value(field.name))|nl2br }}
+                                {{ string(form.value(scope ~ field.name))|nl2br }}
                             {% endif %}
                         {% endblock %}
                     </div>
@@ -29,11 +31,12 @@
             {% endif %}
         {% else %}
             {% if field.fields %}
-                {{ _self.render_field(form, field.fields) }}
+                {% set new_scope = field.nest_id ? scope ~ field.id ~ '.' : scope %}
+                {{ _self.render_field(form, field.fields, new_scope) }}
             {% endif %}
         {% endif %}
     {% endfor %}
 {% endmacro %}
 
-{{ _self.render_field(form, form.fields) }}
+{{ _self.render_field(form, form.fields, '') }}
 

--- a/templates/forms/default/data.html.twig
+++ b/templates/forms/default/data.html.twig
@@ -31,7 +31,7 @@
             {% endif %}
         {% else %}
             {% if field.fields %}
-                {% set new_scope = field.nest_id ? scope ~ field.id ~ '.' : scope %}
+                {% set new_scope = field.nest_id ? scope ~ field.name ~ '.' : scope %}
                 {{ _self.render_field(form, field.fields, new_scope) }}
             {% endif %}
         {% endif %}

--- a/templates/forms/default/data.txt.twig
+++ b/templates/forms/default/data.txt.twig
@@ -1,16 +1,17 @@
-{%- macro render_field(form, fields) %}
+{%- macro render_field(form, fields, scope) %}
 {%- for index, field in fields %}
     {%- set input = attribute(field, "input@") %}
         {%- if input is null or input == true %}
-        {%- set value = form.value(field.name ?? index) %}
-        {{- field.name ?? index }}: {{ string(value is iterable ? value|json_encode : value|escape('yaml')) ~ "\r\n" }}
+        {%- set value = form.value(scope ~ (field.name ?? index)) %}
+        {{- scope ~ (field.name ?? index) }}: {{ string(value is iterable ? value|json_encode : value|escape('yaml')) ~ "\r\n" }}
     {%- else %}
         {%- if field.fields %}
-        {{- _self.render_field(form, field.fields) }}
+        {%- set new_scope = field.nest_id ? scope ~ field.id ~ '.' : scope -%}
+        {{- _self.render_field(form, field.fields, new_scope) }}
         {%- endif %}
     {%- endif %}
 {%- endfor %}
 {%- endmacro %}
 {%- autoescape false %}
-{{- _self.render_field(form, form.fields) ~ "\r\n" }}
+{{- _self.render_field(form, form.fields, '') ~ "\r\n" }}
 {%- endautoescape %}

--- a/templates/forms/default/data.txt.twig
+++ b/templates/forms/default/data.txt.twig
@@ -6,7 +6,7 @@
         {{- scope ~ (field.name ?? index) }}: {{ string(value is iterable ? value|json_encode : value|escape('yaml')) ~ "\r\n" }}
     {%- else %}
         {%- if field.fields %}
-        {%- set new_scope = field.nest_id ? scope ~ field.id ~ '.' : scope -%}
+        {%- set new_scope = field.nest_id ? scope ~ field.name ~ '.' : scope -%}
         {{- _self.render_field(form, field.fields, new_scope) }}
         {%- endif %}
     {%- endif %}

--- a/templates/forms/fields/fieldset/fieldset.html.twig
+++ b/templates/forms/fields/fieldset/fieldset.html.twig
@@ -1,4 +1,4 @@
-{% set scope = field.nest_id ? scope ~ field.id ~ '.' : scope %}
+{% set scope = field.nest_id ? scope ~ field.name ~ '.' : scope %}
 <fieldset {% if field.id is defined %}id="{{ field.id }}"{% endif %} {% if field.classes is defined %}class="{{ field.classes }}" {% endif %}>
 {% if field.legend %}
     <legend>{% if grav.twig.twig.filters['tu'] is defined %}{{ field.legend|tu }}{% else %}{{ field.legend|t }}{% endif %}</legend>

--- a/templates/forms/fields/fieldset/fieldset.html.twig
+++ b/templates/forms/fields/fieldset/fieldset.html.twig
@@ -1,3 +1,4 @@
+{% set scope = field.nest_id ? scope ~ field.id ~ '.' : scope %}
 <fieldset {% if field.id is defined %}id="{{ field.id }}"{% endif %} {% if field.classes is defined %}class="{{ field.classes }}" {% endif %}>
 {% if field.legend %}
     <legend>{% if grav.twig.twig.filters['tu'] is defined %}{{ field.legend|tu }}{% else %}{{ field.legend|t }}{% endif %}</legend>


### PR DESCRIPTION
This allows you to set an option in the `fieldset` (and potentially other nesting fields with minor changes), so that the data is prefixed by the id of the field.

Up to this point (and for backwards compatibility), nested fields like `fieldset`, were just flattened like so:

```
first_field: scooner
second_field: tugboat
name: my-slug
```

But with the fieldset field definition containing `nest_id: true`:

```
test-fieldset:
    type: fieldset
    legend: 'Test Fieldset'
    nest_id: true
```

results in data structured:

```
test-fieldset.first_field: scooner
test-fieldset.second_field: tugboat
name: my-slug
```