### PR TITLE
Fix HTML data template for checkboxes fields where 'use' property is "keys"

### DIFF
--- a/templates/forms/default/data.html.twig
+++ b/templates/forms/default/data.html.twig
@@ -14,8 +14,10 @@
                         {% block field_value %}
                             {% if field.type == 'checkboxes' %}
                                 <ul>
-                                    {% for value in form.value(scope ~ field.name) %}
-                                        <li>{{ field.options[value]|e }}</li>
+                                    {% set use_keys = field.use is defined and field.use == 'keys' %}
+                                    {% for key,value in form.value(field.name) %}
+                                        {% set index = (use_keys ? key : value) %}
+                                        <li>{{ field.options[index]|e }}</li>
                                     {% endfor %}
                                 </ul>
                             {% elseif field.type == 'checkbox' %}

--- a/templates/forms/default/data.html.twig
+++ b/templates/forms/default/data.html.twig
@@ -15,7 +15,7 @@
                             {% if field.type == 'checkboxes' %}
                                 <ul>
                                     {% set use_keys = field.use is defined and field.use == 'keys' %}
-                                    {% for key,value in form.value(field.name) %}
+                                    {% for key,value in form.value(scope ~ field.name) %}
                                         {% set index = (use_keys ? key : value) %}
                                         <li>{{ field.options[index]|e }}</li>
                                     {% endfor %}


### PR DESCRIPTION
Fixes change introduced in afa6eab in response to #121. Commit supported option value as index but broke rendering with option `use: keys`.