### PR TITLE
Allow formdata to show placeholder if label is false

### DIFF
--- a/templates/forms/default/data.html.twig
+++ b/templates/forms/default/data.html.twig
@@ -8,7 +8,11 @@
                 {% block field %}
                     <div>
                         {% block field_label %}
-                            <strong>{{ field.label|t|e }}</strong>:
+                            {% if field.label is not same as(false) %}
+                                <strong>{{ field.label|t|e }}</strong>:
+                            {% else %}
+                                <strong>{{ field.placeholder|t|e }}</strong>:
+                            {% endif %}
                         {% endblock %}
 
                         {% block field_value %}


### PR DESCRIPTION
If a form label is set to false then we could use placeholder instead. Especially useful since many modern designs use placeholder over label. Of course its possible to set the label and then use css to display:none but since label as false is already supported via the default/field.html.twig this should not make any extra difference.

I have tried to extend the forms/data.html.twig to replace just this block but since it is inside a macro the block `field_label` cannot be overridden in an extended template anyway