### PR TITLE
Fixed multiple select optgroup selected bug

### DIFF
--- a/templates/forms/fields/select_optgroup/select_optgroup.html.twig
+++ b/templates/forms/fields/select_optgroup/select_optgroup.html.twig
@@ -22,7 +22,8 @@
                     data-key-observe="{{ (scope ~ field.name)|fieldName }}"
                 {% endif %}
                 >
-            {% if field.placeholder %}<option value="" disabled selected>{% if grav.twig.twig.filters['tu'] is defined %}{{ field.placeholder|tu|raw }}{% else %}{{ field.placeholder|t|raw }}{% endif %}</option>{% endif %}
+                {% set selectedoption = false %}
+            {% if field.placeholder %}<option value="" disabled selected>{% set selectedoption = true %}{% if grav.twig.twig.filters['tu'] is defined %}{{ field.placeholder|tu|raw }}{% else %}{{ field.placeholder|t|raw }}{% endif %}</option>{% endif %}
 
             {% for key, optgroup in field.options %}
                 {% set optgroup_label = optgroup|keys|first %}
@@ -31,7 +32,7 @@
                 {%for subkey, suboption in field.options[key][optgroup_label] %}
                 {% set selected = field.selectize ? suboption : subkey %}
                 {% set item_value = field.selectize and field.multiple ? suboption : subkey %}
-                    <option {% if subkey == value or (field.multiple and selected in value) %}selected="selected"{% endif %} value="{{ suboption }}">
+                    <option {% if selectedoption == false subkey == value or (field.multiple and selected in value) %}{% set selectedoption = true %}selected="selected"{% endif %} value="{{ suboption }}">
                         {% if grav.twig.twig.filters['tu'] is defined %}
                         {{ suboption|tu|raw }}{% else %}{{ suboption|t|raw }}
                         {% endif %}


### PR DESCRIPTION
Right now, if you use 2 select optgroups it just automatically selects the first option of every group. It also ignores the placeholder.

This fix checks for a placeholder and uses that. If not, it just uses the first selection of the first group, and doesn't set any others to "selected"