### PR TITLE
added markdown parsing to textarea labels, in the spirit of f19a65b7d…

### DIFF
--- a/templates/forms/fields/textarea/textarea.html.twig
+++ b/templates/forms/fields/textarea/textarea.html.twig
@@ -1,7 +1,19 @@
 {% extends "forms/field.html.twig" %}
 
+{% block label %}
+{% endblock %}
+
 {% block input %}
+    {% set id = field.id|default(field.name) ~ '-' ~ key %}
     <div class="{{ form_field_wrapper_classes ?: 'form-textarea-wrapper' }} {{ field.size }} {{ field.wrapper_classes }}">
+        <label style="display:inline;" class="inline" for="{{ id|e }}">
+            {% if field.markdown %}
+                {{ field.label|t|markdown(false) }}
+            {% else %}
+                {{ field.label|t|e }}
+            {% endif %}
+            {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}
+        </label>
         <textarea
             {# required attribute structures #}
             name="{{ (scope ~ field.name)|fieldName }}"


### PR DESCRIPTION
This is a proposed solution to the problem in

https://discourse.getgrav.org/t/markdown-in-form-label-to-add-page-link/5386/8

i.e. markdown parsing in textarea labels. It's basically copy-pasta of the relevant parts in f19a65b7dfa2e369d9e20ef07816ed6ad5497495