### PR TITLE
Form attributes improvements

### DIFF
--- a/templates/forms/default/form.html.twig
+++ b/templates/forms/default/form.html.twig
@@ -4,7 +4,7 @@
 
 {% include 'partials/form-messages.html.twig' %}
 
-{% set scope = scope ?: 'data.' %}
+{% set scope = scope ? : form.scope is not none ? form.scope : 'data.' %}
 {% set multipart = '' %}
 {% set blueprints = blueprints ?? form.blueprint() %}
 {% set method = form.method|upper|default('POST') %}

--- a/templates/forms/default/form.html.twig
+++ b/templates/forms/default/form.html.twig
@@ -17,7 +17,11 @@
     {% endif %}
 {% endfor %}
 
-{% set action = form.action ? base_url ~ form.action : base_url ~ page.route ~ uri.params %}
+{% if form.action %}
+  {% set action = form.action starts with 'http://' or form.action starts with 'https://' ? form.action : base_url ~ form.action %}
+{% else %}
+  {% set action = base_url ~ page.route ~ uri.params %}
+{% endif %}
 
 {% if (action == base_url_relative) %}
     {% set action = base_url_relative ~ '/' ~ page.slug %}

--- a/templates/forms/default/form.html.twig
+++ b/templates/forms/default/form.html.twig
@@ -4,7 +4,7 @@
 
 {% include 'partials/form-messages.html.twig' %}
 
-{% set scope = scope ? : form.scope is not none ? form.scope : 'data.' %}
+{% set scope = scope ? : form.scope is defined ? form.scope : 'data.' %}
 {% set multipart = '' %}
 {% set blueprints = blueprints ?? form.blueprint() %}
 {% set method = form.method|upper|default('POST') %}
@@ -18,7 +18,7 @@
 {% endfor %}
 
 {% if form.action %}
-  {% set action = form.action starts with 'http://' or form.action starts with 'https://' ? form.action : base_url ~ form.action %}
+  {% set action = grav.uri.isExternal(form.action) ? form.action : base_url ~ form.action %}
 {% else %}
   {% set action = base_url ~ page.route ~ uri.params %}
 {% endif %}

--- a/templates/forms/default/form.html.twig
+++ b/templates/forms/default/form.html.twig
@@ -56,6 +56,9 @@
       {% endblock %}
       {% if form.novalidate %}novalidate{% endif %}
       {% if form.keep_alive %}data-grav-keepalive="true"{% endif %}
+      {% for k, v in form.data.blueprints.form %}
+        {% if k starts with 'data-' %}{{ k }}="{{ v|e }}"{% endif %}
+      {% endfor %}
 >
 
   {% block inner_markup_fields_start %}{% endblock %}


### PR DESCRIPTION
* allow form scope to be set from form parameters
* allow form action to be set to a remote URL `(http|https://`) without being forcefully prefixed
* form now supports `data-*`or `config-data-*@` form parameters to be used as `<form>` attributes 

See #173 and #293