### PR TITLE
PHP-defined <select> options can further specify attributes.

### DIFF
--- a/templates/forms/fields/select/select.html.twig
+++ b/templates/forms/fields/select/select.html.twig
@@ -30,7 +30,14 @@
             {% endif %}
 
             {% for key, item_value in options %}
-                {% if item_value is iterable %}
+                {% if item_value is iterable and item_value.value %}
+                    {% set akey = field.selectize and field.multiple ? item_value : key %}
+                    {% set avalue = grav.twig.twig.filters['tu'] is defined ? item_value.value|tu : item_value.value|t %}
+                    <option {{ item_value.disabled ? 'disabled="disabled"' : '' }}
+			    {{ item_value.selected ? 'selected="selected"' : '' }}
+			    {{ item_value.label    ? 'label=' ~ item_value.label : '' }}
+			    value="{{ item_value.akey }}">{{ avalue|raw }}</option>
+                {% elseif item_value is iterable %}
                     <optgroup label="{{ key }}">
                         {%for subkey, suboption in item_value %}
                             {% set selected = field.selectize ? suboption : subkey %}


### PR DESCRIPTION
Example:
`return ['AF' => 'Afghanistan', 'DZ' => ['value' => 'Algeria', 'selected' => 1], 'AS' => ['value' => 'American Samoa', 'disabled' => 1]];`

Supported attributes: `selected`, `disabled` and `label`

Note: For compatibility reason, the "`value`" subkey actually represents <option> text
      while the top level array key represents actual option's "value" attribute.