### PR TITLE
Fix reCAPTCHA version option typo

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -175,7 +175,7 @@ form:
           default: 2-checkbox
           options:
             2-checkbox: v2 - Checkbox
-            2-invsiible: v2 - Invisible
+            2-invisible: v2 - Invisible
             3: v3 - Latest
         recaptcha.site_key:
           type: text


### PR DESCRIPTION
This PR fixes the typo in the recaptcha version select (`blueprints.yaml`). Because of this, the code for repcatcha 2 invisible in `captcha.html.twig` was not executing.