### PR TITLE
missing npm build-time dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,12 @@
     "gulp-rename": "^1.4.0",
     "gulp-sass": "^4.0.1",
     "gulp-sourcemaps": "^2.6.4",
+    "gulp-webpack": "^1.5.0",
+    "immutable": "^4.0.0-rc.12",
     "imports-loader": "^0.8.0",
     "json-loader": "^0.5.7",
     "style-loader": "^0.23.0",
+    "uglifyjs-webpack-plugin": "^2.0.1",
     "webpack": "^4.19.1",
     "webpack-cli": "^3.1.0"
   }


### PR DESCRIPTION
The toolchain makes use of dependencies which are not part of `package.json`:
  `npm install --save-dev gulp-webpack immutable uglifyjs-webpack-plugin`
See #291 