### PR TITLE
Ability to provide all initialized forms

### DIFF
--- a/form.php
+++ b/form.php
@@ -588,6 +588,16 @@ class FormPlugin extends Plugin
     }
 
     /**
+     * function to get initialized forms
+     *
+     * @return array
+     */
+    public function getForms()
+    {
+      return $this->forms;
+    }
+
+    /**
      * function to get a specific form
      *
      * @param null|array|string $data optional form `name`


### PR DESCRIPTION
Provide `Form->getForms()` that return initialized forms.

If I want to post-process a form (disregarding caching), I may use `getForm()` but it's too limited.
If I'm only interested in forms having a `xtra_field` set to `1`, independently of their name or route, I'm stuck. Moreover `getForm()` fails when it comes to modular pages.

So just give users and developers the power to proceed with their data. Don't lock them with `protected` properties when API do not provide any (right) way to access such a data.

See also https://github.com/getgrav/grav/pull/2277

edit: `flat_forms` may be better after all.