### PR TITLE
improve route-based selection when multiple partial forms have the same slug

### DIFF
--- a/form.php
+++ b/form.php
@@ -694,7 +694,7 @@ class FormPlugin extends Plugin
             if (!empty($this->forms[$page_route])) {
                 $forms = $this->forms[$page_route];
                 $first_form = reset($forms);
-                $form_name = $first_form['name'] ?? null;
+                return $first_form;
             } else {
                 //No form on this route. Try looking up in the current page first
                 /** @var Forms $forms */


### PR DESCRIPTION
When a form is requested by route, the routine extract the matching one then get its name, and then fetch form by name.
Not only is this sub-optimal but create a bug when two forms share the same name.

Eg: a form is used as part of a modular page and dynamically included in the template by its name. If another modular page exists, containing a page with an identical form slug, then this will fail.

=> In case a route is requested and form exists: just return it immediately.