### PR TITLE
Show the `description` span even for an empty description

### DIFF
--- a/templates/forms/layouts/field.html.twig
+++ b/templates/forms/layouts/field.html.twig
@@ -39,7 +39,7 @@
           </div>
         {% endblock %}
       {% endblock %}
-      {% if field.description %}
+      {% if field.description is defined %}
         <div class="{{ form_field_extra_wrapper_classes }}">
           <span class="form-description">
             {{ form_field_description|raw }}


### PR DESCRIPTION
Show the `description` span even for an empty description because this field, even if empty at initial page load may be used and changed by javascript listeners.
This change allows author to user `description: ""` (empty string) to force its presence.