### PR TITLE
add markdown evaluation to labels

### DIFF
--- a/templates/forms/default/data.html.twig
+++ b/templates/forms/default/data.html.twig
@@ -11,17 +11,9 @@
                     <div>
                         {% block field_label %}
                             {% if field.markdown %}
-                                {% if grav.twig.twig.filters['tu'] is defined %}
-                                    <strong>{{ field.label|tu|markdown(false) }}</strong>:
-                                {% else %}
-                                    <strong>{{ field.label|t|markdown(false) }}</strong>:
-                                {% endif %}
+                                <strong>{{ field.label|t|markdown(false) }}</strong>:
                             {% else %}
-                                {% if grav.twig.twig.filters['tu'] is defined %}
-                                    <strong>{{ field.label|tu|e }}</strong>:
-                                {% else %}
-                                    <strong>{{ field.label|t|e }}</strong>:
-                                {% endif %}
+                                <strong>{{ field.label|t|e }}</strong>:
                             {% endif %}
                         {% endblock %}
 

--- a/templates/forms/default/data.html.twig
+++ b/templates/forms/default/data.html.twig
@@ -10,7 +10,19 @@
                 {% block field %}
                     <div>
                         {% block field_label %}
-                            <strong>{{ field.label|t|e }}</strong>:
+                            {% if field.markdown %}
+                                {% if grav.twig.twig.filters['tu'] is defined %}
+                                    <strong>{{ field.label|tu|markdown(false) }}</strong>:
+                                {% else %}
+                                    <strong>{{ field.label|t|markdown(false) }}</strong>:
+                                {% endif %}
+                            {% else %}
+                                {% if grav.twig.twig.filters['tu'] is defined %}
+                                    <strong>{{ field.label|tu|e }}</strong>:
+                                {% else %}
+                                    <strong>{{ field.label|t|e }}</strong>:
+                                {% endif %}
+                            {% endif %}
                         {% endblock %}
 
                         {% block field_value %}

--- a/templates/forms/fields/checkbox/checkbox.html.twig
+++ b/templates/forms/fields/checkbox/checkbox.html.twig
@@ -26,17 +26,9 @@
             />
         <label style="display:inline;" class="inline" for="{{ id|e }}">
             {% if field.markdown %}
-                {% if grav.twig.twig.filters['tu'] is defined %}
-                    {{ field.label|tu|markdown(false) }}
-                {% else %}
-                    {{ field.label|t|markdown(false) }}
-                {% endif %}
+                {{ field.label|t|markdown(false) }}
             {% else %}
-                {% if grav.twig.twig.filters['tu'] is defined %}
-                    {{ field.label|tu|e }}
-                {% else %}
-                    {{ field.label|t|e }}
-                {% endif %}
+                {{ field.label|t|e }}
             {% endif %}
             {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}
         </label>

--- a/templates/forms/fields/checkbox/checkbox.html.twig
+++ b/templates/forms/fields/checkbox/checkbox.html.twig
@@ -26,9 +26,17 @@
             />
         <label style="display:inline;" class="inline" for="{{ id|e }}">
             {% if field.markdown %}
-                {{ field.label|t|markdown(false) }}
+                {% if grav.twig.twig.filters['tu'] is defined %}
+                    {{ field.label|tu|markdown(false) }}
+                {% else %}
+                    {{ field.label|t|markdown(false) }}
+                {% endif %}
             {% else %}
-                {{ field.label|t|e }}
+                {% if grav.twig.twig.filters['tu'] is defined %}
+                    {{ field.label|tu|e }}
+                {% else %}
+                    {{ field.label|t|e }}
+                {% endif %}
             {% endif %}
             {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}
         </label>

--- a/templates/forms/fields/checkboxes/checkboxes.html.twig
+++ b/templates/forms/fields/checkboxes/checkboxes.html.twig
@@ -12,21 +12,7 @@
     data-grav-field-name="{{ (scope ~ field.name)|fieldName }}"
 {% endblock %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input %}
     {% for key, text in field.options %}

--- a/templates/forms/fields/checkboxes/checkboxes.html.twig
+++ b/templates/forms/fields/checkboxes/checkboxes.html.twig
@@ -12,6 +12,22 @@
     data-grav-field-name="{{ (scope ~ field.name)|fieldName }}"
 {% endblock %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input %}
     {% for key, text in field.options %}
 

--- a/templates/forms/fields/date/date.html.twig
+++ b/templates/forms/fields/date/date.html.twig
@@ -1,20 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input_attributes %}
     type="date"

--- a/templates/forms/fields/date/date.html.twig
+++ b/templates/forms/fields/date/date.html.twig
@@ -1,5 +1,21 @@
 {% extends "forms/field.html.twig" %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input_attributes %}
     type="date"
     {% if field.validate.min %}min="{{ field.validate.min }}"{% endif %}

--- a/templates/forms/fields/display/display.html.twig
+++ b/templates/forms/fields/display/display.html.twig
@@ -6,6 +6,22 @@
     {% set content = field.content %}
 {% endif %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input %}
     <div class="form-display-wrapper {{ field.size }} {{ field.classes }}" {% if field.id is defined %}id="{{ field.id|e }}" {% endif %}>
         {% if field.markdown %}

--- a/templates/forms/fields/display/display.html.twig
+++ b/templates/forms/fields/display/display.html.twig
@@ -6,21 +6,7 @@
     {% set content = field.content %}
 {% endif %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input %}
     <div class="form-display-wrapper {{ field.size }} {{ field.classes }}" {% if field.id is defined %}id="{{ field.id|e }}" {% endif %}>

--- a/templates/forms/fields/email/email.html.twig
+++ b/templates/forms/fields/email/email.html.twig
@@ -1,20 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input_attributes %}
     type="email"

--- a/templates/forms/fields/email/email.html.twig
+++ b/templates/forms/fields/email/email.html.twig
@@ -1,5 +1,21 @@
 {% extends "forms/field.html.twig" %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input_attributes %}
     type="email"
     {% if field.multiple in ['on', 'true', 1] %}multiple="multiple"{% endif %}

--- a/templates/forms/fields/file/file.html.twig
+++ b/templates/forms/fields/file/file.html.twig
@@ -58,21 +58,7 @@
 
 {% do config.set('forms.dropzone.enabled', true) %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input %}
     {% set page_can_upload = exists or (type == 'page' and not exists and not (field.destination starts with '@self' or field.destination starts with 'self@')) %}

--- a/templates/forms/fields/file/file.html.twig
+++ b/templates/forms/fields/file/file.html.twig
@@ -58,6 +58,22 @@
 
 {% do config.set('forms.dropzone.enabled', true) %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input %}
     {% set page_can_upload = exists or (type == 'page' and not exists and not (field.destination starts with '@self' or field.destination starts with 'self@')) %}
     {% set max_filesize = (field.filesize > form_max_filesize or field.filesize == 0) ? form_max_filesize : field.filesize %}

--- a/templates/forms/fields/label/label.html.twig
+++ b/templates/forms/fields/label/label.html.twig
@@ -1,15 +1,7 @@
 {% block label %}
     {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
+        {{ field.label|t|markdown(false) }}
     {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
+        {{ field.label|t|e }}
     {% endif %}
 {% endblock %}

--- a/templates/forms/fields/label/label.html.twig
+++ b/templates/forms/fields/label/label.html.twig
@@ -1,0 +1,15 @@
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/templates/forms/fields/month/month.html.twig
+++ b/templates/forms/fields/month/month.html.twig
@@ -1,20 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input_attributes %}
     type="month"

--- a/templates/forms/fields/month/month.html.twig
+++ b/templates/forms/fields/month/month.html.twig
@@ -1,5 +1,21 @@
 {% extends "forms/field.html.twig" %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input_attributes %}
     type="month"
     {{ parent() }}

--- a/templates/forms/fields/password/password.html.twig
+++ b/templates/forms/fields/password/password.html.twig
@@ -1,5 +1,21 @@
 {% extends "forms/field.html.twig" %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input_attributes %}
     type="password"
     {{ parent() }}

--- a/templates/forms/fields/password/password.html.twig
+++ b/templates/forms/fields/password/password.html.twig
@@ -1,20 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input_attributes %}
     type="password"

--- a/templates/forms/fields/radio/radio.html.twig
+++ b/templates/forms/fields/radio/radio.html.twig
@@ -3,6 +3,22 @@
 {% set originalValue = value %}
 {% set value = (value is null ? field.default : value) %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input %}
     {% for key, text in field.options %}
         {% set id = field.id|default(field.name) ~ '-' ~ key %}

--- a/templates/forms/fields/radio/radio.html.twig
+++ b/templates/forms/fields/radio/radio.html.twig
@@ -3,21 +3,7 @@
 {% set originalValue = value %}
 {% set value = (value is null ? field.default : value) %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input %}
     {% for key, text in field.options %}

--- a/templates/forms/fields/range/range.html.twig
+++ b/templates/forms/fields/range/range.html.twig
@@ -1,20 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input_attributes %}
     type="range"

--- a/templates/forms/fields/range/range.html.twig
+++ b/templates/forms/fields/range/range.html.twig
@@ -1,5 +1,21 @@
 {% extends "forms/field.html.twig" %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input_attributes %}
     type="range"
     {% if field.validate.min %}min="{{ field.validate.min }}"{% endif %}

--- a/templates/forms/fields/select/select.html.twig
+++ b/templates/forms/fields/select/select.html.twig
@@ -5,6 +5,22 @@
     {{ parent() }}
 {% endblock %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input %}
     <div class="{{ form_field_wrapper_classes ?: 'form-select-wrapper' }} {{ field.size }} {{ field.wrapper_classes }}">
         <select name="{{ (scope ~ field.name)|fieldName ~ (field.multiple ? '[]' : '') }}"

--- a/templates/forms/fields/select/select.html.twig
+++ b/templates/forms/fields/select/select.html.twig
@@ -5,21 +5,7 @@
     {{ parent() }}
 {% endblock %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input %}
     <div class="{{ form_field_wrapper_classes ?: 'form-select-wrapper' }} {{ field.size }} {{ field.wrapper_classes }}">

--- a/templates/forms/fields/select_optgroup/select_optgroup.html.twig
+++ b/templates/forms/fields/select_optgroup/select_optgroup.html.twig
@@ -5,6 +5,22 @@
     {{ parent() }}
 {% endblock %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input %}
     <div class="{{ form_field_wrapper_classes ?: 'form-select-wrapper' }} {{ field.size }} {{ field.wrapper_classes }}">
         <select name="{{ (scope ~ field.name)|fieldName ~ (field.multiple ? '[]' : '') }}"

--- a/templates/forms/fields/select_optgroup/select_optgroup.html.twig
+++ b/templates/forms/fields/select_optgroup/select_optgroup.html.twig
@@ -5,21 +5,7 @@
     {{ parent() }}
 {% endblock %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input %}
     <div class="{{ form_field_wrapper_classes ?: 'form-select-wrapper' }} {{ field.size }} {{ field.wrapper_classes }}">

--- a/templates/forms/fields/tel/tel.html.twig
+++ b/templates/forms/fields/tel/tel.html.twig
@@ -1,20 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input_attributes %}
     type="tel"

--- a/templates/forms/fields/tel/tel.html.twig
+++ b/templates/forms/fields/tel/tel.html.twig
@@ -1,5 +1,21 @@
 {% extends "forms/field.html.twig" %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input_attributes %}
     type="tel"
     {{ parent() }}

--- a/templates/forms/fields/text/text.html.twig
+++ b/templates/forms/fields/text/text.html.twig
@@ -1,20 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block prepend %}
 {% if field.prepend %}

--- a/templates/forms/fields/text/text.html.twig
+++ b/templates/forms/fields/text/text.html.twig
@@ -1,5 +1,21 @@
 {% extends "forms/field.html.twig" %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block prepend %}
 {% if field.prepend %}
     <div class="form-input-addon form-input-prepend">

--- a/templates/forms/fields/textarea/textarea.html.twig
+++ b/templates/forms/fields/textarea/textarea.html.twig
@@ -1,5 +1,21 @@
 {% extends "forms/field.html.twig" %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input %}
     <div class="{{ form_field_wrapper_classes ?: 'form-textarea-wrapper' }} {{ field.size }} {{ field.wrapper_classes }}">
         {% block prepend %}{% endblock prepend %}

--- a/templates/forms/fields/textarea/textarea.html.twig
+++ b/templates/forms/fields/textarea/textarea.html.twig
@@ -1,20 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input %}
     <div class="{{ form_field_wrapper_classes ?: 'form-textarea-wrapper' }} {{ field.size }} {{ field.wrapper_classes }}">

--- a/templates/forms/fields/time/time.html.twig
+++ b/templates/forms/fields/time/time.html.twig
@@ -1,5 +1,21 @@
 {% extends "forms/field.html.twig" %}
 
+{% block label %}
+    {% if field.markdown %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|markdown(false) }}
+        {% else %}
+            {{ field.label|t|markdown(false) }}
+        {% endif %}
+    {% else %}
+        {% if grav.twig.twig.filters['tu'] is defined %}
+            {{ field.label|tu|e }}
+        {% else %}
+            {{ field.label|t|e }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block input_attributes %}
     type="time"
     {{ parent() }}

--- a/templates/forms/fields/time/time.html.twig
+++ b/templates/forms/fields/time/time.html.twig
@@ -1,20 +1,6 @@
 {% extends "forms/field.html.twig" %}
 
-{% block label %}
-    {% if field.markdown %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|markdown(false) }}
-        {% else %}
-            {{ field.label|t|markdown(false) }}
-        {% endif %}
-    {% else %}
-        {% if grav.twig.twig.filters['tu'] is defined %}
-            {{ field.label|tu|e }}
-        {% else %}
-            {{ field.label|t|e }}
-        {% endif %}
-    {% endif %}
-{% endblock %}
+{% use "forms/fields/label/label.html.twig" %}
 
 {% block input_attributes %}
     type="time"


### PR DESCRIPTION
Added missing markdown evaluation of checkbox labels within data.html.twig if activated. To be able to send the agreed terms of condition as link within an email - see #227 and #253
Translate the label into the current language set in the admin interface user preferences if defined.
Furthermore added the possibility to use markdown syntax within labels of checkboxes, date, display, email, file, month, password, radio, range, select_optgroup, select, tel, text, textarea, and time too - see #281