### PR TITLE
Visual upgrade to form field descriptions

### DIFF
--- a/templates/forms/default/field.html.twig
+++ b/templates/forms/default/field.html.twig
@@ -113,7 +113,7 @@
                     {% endblock %}
                 {% endblock %}
                 {% if field.description %}
-                    <div class="form-extra-wrapper {{ field.size|e }} {{ field.wrapper_classes }}">
+                    <div class="form-extra-wrapper {{ field.wrapper_classes }}">
                         <span class="form-description">
                             {% if field.markdown %}
                                 {{ field.description|t|markdown(false)|raw }}


### PR DESCRIPTION
Currently when making a small field (usually for something like a number) but a description is needed this is the result:

![image](https://i.imgur.com/fkRlqPv.png)

This PR suggests removing the class from the description so it can be full width and result like this:

![image](https://i.imgur.com/auqRdYJ.png)