### PR TITLE
Allow passing arbitrary form attributes

### DIFF
--- a/templates/forms/default/form.html.twig
+++ b/templates/forms/default/form.html.twig
@@ -111,6 +111,12 @@
     class="{{ parent() }} {{ override_form_classes|trim }}"
   {%- endblock %}
 
+  {% block embed_form_custom_attributes %}
+    {% for k, v in blueprints.form.attributes %}
+      {{ k }}="{{ v|e }}"
+    {% endfor %}
+  {% endblock %}
+
   {% block embed_fields %}
     {{ override_inner_markup_fields_start|raw }}
     {{ override_inner_markup_fields|raw }}

--- a/templates/forms/layouts/form.html.twig
+++ b/templates/forms/layouts/form.html.twig
@@ -1,6 +1,7 @@
 <form
     {% block embed_form_core %}{% endblock %}
     {% block embed_form_classes %}{% endblock %}
+    {% block embed_form_custom_attributes %}{% endblock %}
 >
   {% block embed_fields %}{% endblock %}
   {% block embed_buttons %}{% endblock %}


### PR DESCRIPTION
Form support for `data-*`or `config-data-*@` parameters to be used as `<form>` attributes 

See #173 and #293 and #294 