### PR TITLE
Prefer forms matching by route to avoid wrong result in case of name collision (was #309)

### DIFF
--- a/form.php
+++ b/form.php
@@ -747,7 +747,7 @@ class FormPlugin extends Plugin
             if (!empty($this->forms[$page_route])) {
                 $forms = $this->forms[$page_route];
                 $first_form = reset($forms) ?: null;
-                $form_name = $first_form['name'] ?? null;
+                return $first_form;
             } else {
                 //No form on this route. Try looking up in the current page first
                 /** @var Forms $forms */


### PR DESCRIPTION
When a form is requested by route, the routine extract the matching one then get its name, and then fetch form by name.
Not only is this sub-optimal but create a bug when two forms share the same name.

Eg: a **form is used as part of a modular page** and dynamically included in the template by its name. If another modular page exists, containing a page with an identical form slug, then this will fail.
- create two modular pages, each including a form, eg:
  - `01.aaaa/01._formular/form.de_DE.md:    title: form-for-aaaa`
  - `02.bbbb/01._formular/form.de_DE.md:    title: form-for-bbbb`
- You'll encounter that `01.aaaa` is using `02.bbbb`'s form or vice-and-versa **!!**

=> In case a route is requested and form exists: just return it immediately.

It may _radically change which forms get selected_. See previous PR #309 