### PR TITLE
dont escape label markdown

### DIFF
--- a/templates/forms/default/field.html.twig
+++ b/templates/forms/default/field.html.twig
@@ -53,7 +53,7 @@
                             {% endif %}
                         {% else %}
                             {% if field.markdown %}
-                                {{ field.label|markdown(false)|default(field.name|capitalize)|t|e('html_attr') }}
+                                {{ field.label|markdown(false)|default(field.name|capitalize)|t }}
                             {% else %}
                                 {{ field.label|default(field.name|capitalize)|t|e('html_attr') }}
                             {% endif %}


### PR DESCRIPTION
This PR is to fix a bug with escaping markdown label.

if we have for example:
```
 date:
      type: text
      label: '**Choose a date**'
      markdown: true
```
it will result in `<strong>Choose a date</strong>` when it should result in **Choose a date**
