### PR TITLE
Fix `accept` for SVG files in `file` uploaders:

### DIFF
--- a/classes/Form.php
+++ b/classes/Form.php
@@ -586,7 +586,7 @@ class Form implements FormInterface, \ArrayAccess
             }
 
             $isMime = strstr($type, '/');
-            $find   = str_replace(['.', '*'], ['\.', '.*'], $type);
+            $find   = str_replace(['.', '*', '+'], ['\.', '.*', '\+'], $type);
 
             if ($isMime) {
                 $match = preg_match('#' . $find . '$#', $mime);


### PR DESCRIPTION
Using `accept: 'image/svg+xml' to only allow SVG file to be uploaded should now work.

The `preg_match` was comparing `svgggg…xml` with `svg+xml`.

Check the [List of Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml#image) for more potential issues.