### PR TITLE
Use curl for captcha validation if available

### DIFF
--- a/form.php
+++ b/form.php
@@ -19,6 +19,7 @@ use Grav\Framework\Route\Route;
 use Grav\Plugin\Form\Form;
 use Grav\Plugin\Form\Forms;
 use ReCaptcha\ReCaptcha;
+use ReCaptcha\RequestMethod\CurlPost;
 use RocketTheme\Toolbox\File\JsonFile;
 use RocketTheme\Toolbox\File\YamlFile;
 use RocketTheme\Toolbox\File\File;
@@ -399,6 +400,9 @@ class FormPlugin extends Plugin
                 $ip = Uri::ip();
 
                 $recaptcha = new ReCaptcha($secret);
+                if(extension_loaded('curl')){
+                    $recaptcha = new ReCaptcha($secret, new CurlPost());
+                }
 
                 // get captcha version
                 $captcha_version = $captcha_config['version'] ?? 2;


### PR DESCRIPTION
Some servers have `allow_url_fopen` disabled for security purposes. The ReCaptcha class relies on this by default, specifically through `file_get_contents()`, breaking validation for these servers.

This change allows the use of curl if it's available otherwise reverts to the default behavior.