### PR TITLE
allow an empty form scope to be set from form parameters

### DIFF
--- a/templates/forms/default/form.html.twig
+++ b/templates/forms/default/form.html.twig
@@ -4,7 +4,7 @@
 
 {% include 'partials/form-messages.html.twig' %}
 
-{% set scope = scope ?: 'data.' %}
+{% set scope = scope ?: form.scope is defined ? form.scope : 'data.' %}
 {% set multipart = '' %}
 {% set blueprints = blueprints ?? form.blueprint() %}
 {% set method = form.method|upper|default('POST') %}


### PR DESCRIPTION
Was part of #293, #294 and #336 here provided individually.