### PR TITLE
tabs: count is not a standard Twig filter. length is

### DIFF
--- a/templates/forms/fields/tabs/tabs.html.twig
+++ b/templates/forms/fields/tabs/tabs.html.twig
@@ -15,7 +15,7 @@
         {% set tabs = tabs|merge([tab]) %}
         {% endif %}
     {% endfor %}
-    {% set count = tabs|count %}
+    {% set count = tabs|length %}
 
     {% if count == 0 %}
         {# Nothing to display #}


### PR DESCRIPTION
`count` is not a standard Twig filter. [length](https://twig.symfony.com/doc/2.x/filters/length.html) is