### PR TITLE
Move form messages block from default/form template to layouts/form

### DIFF
--- a/templates/forms/default/form.html.twig
+++ b/templates/forms/default/form.html.twig
@@ -2,8 +2,6 @@
     {% set form = grav.session.getFlashObject('form') %}
 {% endif  %}
 
-{% include 'partials/form-messages.html.twig' %}
-
 {% set scope = scope ?: form.scope is defined ? form.scope : 'data.' %}
 {% set multipart = '' %}
 {% set blueprints = blueprints ?? form.blueprint() %}

--- a/templates/forms/layouts/form.html.twig
+++ b/templates/forms/layouts/form.html.twig
@@ -1,3 +1,5 @@
+{% include 'partials/form-messages.html.twig' %}
+
 <form
     {% block embed_form_core %}{% endblock %}
     {% block embed_form_classes %}{% endblock %}


### PR DESCRIPTION
This allows more flexibility in positioning the messages partial. The messages block is the only remaining layout part of the default/form template. It makes more sense and is easier to customise in the layouts folder.

You also might want to consider creating a new embed block to be consistent with the other blocks in there .. your preference.