### PR TITLE
Ability to overwrite fields after the form is submitted, but before actions are taken.

### DIFF
--- a/form.php
+++ b/form.php
@@ -384,9 +384,11 @@ class FormPlugin extends Plugin
         $action = $event['action'];
         $params = $event['params'];
 
-        $this->process($form);
-
         switch ($action) {
+            case 'process':
+                $this->process($form);
+                break;
+
             case 'captcha':
 
                 $captcha_config = $this->config->get('plugins.form.recaptcha');
@@ -856,6 +858,14 @@ class FormPlugin extends Plugin
         foreach ($form->fields as $field) {
             if (!empty($field['process']['fillWithCurrentDateTime'])) {
                 $form->setData($field['name'], gmdate('D, d M Y H:i:s', time()));
+            }
+            if (!empty($field['process']['twig'])) {
+                $twig = $this->grav['twig'];
+                $vars = [
+                    'form' => $form
+                ];
+                // Process with Twig
+                $form->setData($field['name'], $twig->processString($field['process']['twig'], $vars));
             }
         }
     }


### PR DESCRIPTION
Any form field can be equipped with the following:
```
process:
    twig: some twig markup goes here
```
Additionally, form is equipped with a new type of action "process". When process action is called, all process:twig contents of all fields are evaluated and the results are saved in the values of these fields. For instance
```
form:
    fields:
        -
            type: hidden
            name: path
            process:
                twig: "/blog/{{ grav.page.folder }}"
    process:
        -
            process: true
        -
            addComment: true
```
After the form is submitted, before saving the comment the field "path" is evaluated to /blog/{{ grav.page.folder }}.

This helps to resolve a bug in comments plugin. This can also be used to automatically save date, username and other things in add-page-by-form plugin.