### PR TITLE
Added rating field

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -72,6 +72,7 @@ en:
     DESTINATION_NOT_SPECIFIED: "Destination not specified"
     INVALID_MIME_TYPE: "The MIME type %s for the file %s is not accepted."
     INVALID_FILE_EXTENSION: "The File Extension for the file %s is not accepted."
+    STARS: "Stars"
 eu:
   PLUGIN_FORM:
     NOT_VALIDATED: "Formularioa ez da baliozkotu. Beharrezkoa den eremu bat edo gehiago falta dira."

--- a/scss/form-styles.scss
+++ b/scss/form-styles.scss
@@ -175,6 +175,7 @@ $form-active-color: #000;
 .rating {
   border: none;
   float: left;
+  margin: 0;
 
   > input {
     display: none;

--- a/scss/form-styles.scss
+++ b/scss/form-styles.scss
@@ -171,6 +171,41 @@ $form-active-color: #000;
     }
 }
 
+// 5 Star Rating
+.rating {
+  border: none;
+  float: left;
+
+  > input {
+    display: none;
+  }
+
+  > label:before {
+    margin: 5px;
+    font-size: 1.25em;
+    font-family: FontAwesome;
+    display: inline-block;
+    content: "\f005";
+  }
+
+  > .half:before {
+    content: "\f089";
+    position: absolute;
+  }
+
+  > label {
+    color: #ddd;
+    float: right;
+  }
+
+  // Selected star color
+  > input:checked ~ label { color: #FFD700;  }
+
+  // Hover star color
+  &:not(:checked) > label:hover,
+  &:not(:checked) > label:hover ~ label { color: inherit;  }
+}
+
 // Toggleable
 .form-field-toggleable {
     .checkboxes.toggleable {

--- a/templates/forms/fields/rating/rating.html.twig
+++ b/templates/forms/fields/rating/rating.html.twig
@@ -1,0 +1,28 @@
+{% extends "forms/field.html.twig" %}
+
+{% set originalValue = value %}
+{% set value = (value is null ? field.default : value) %}
+
+{% block input %}
+    <fieldset class="rating">
+        {# It is important to count from max to min, as this is required by the css. #}
+        {% for i in field.validate.max|default(5)..field.validate.min|default(1) %}
+            {% set id = field.id|default(field.name) ~ '-star' ~ i %}
+            <input type="radio"
+                   value="{{ i|e }}"
+                   id="{{ id|e }}"
+                   name="{{ (scope ~ field.name)|fieldName }}"
+                   {% if field.classes is defined %}class="{{ field.classes }}" {% endif %}
+                   {% if i == value %}checked="checked" {% endif %}
+                   {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}
+                   {% if required %}required="required"{% endif %}
+                   {% if field.tabindex %}tabindex="{{ field.tabindex }}"{% endif %}
+            />
+            <label class="full" for="{{ id|e }}" title="{{ field.titles[i]|default(i ~ ' ' ~ 'PLUGIN_FORM.STARS'|t)|t }}"></label>
+        {% endfor %}
+    </fieldset>
+
+    {# Ensure that the rest of the form is aligned below and not right to the rating #}
+    <div style="clear:both; float:none;"></div>
+
+{% endblock %}


### PR DESCRIPTION
Hey there!

I've added a simple rating field for grav:
![grafik](https://user-images.githubusercontent.com/6888294/93528433-9d422a80-f93a-11ea-972f-566c214e0cb4.png)

This is my first grav form experience, so please give me feedback on what to improve. I've looked closely at the radio button example and others.

You can configure it like this:

```yaml
- name: rating
  type: rating
  label: Bewertung
  default: 3
  validate:
    min: 1
    max: 5
    required: true
  titles:
      1: Horrible
      2: Bad
      # 3: Average -> Will use default '3 Stars' title
      4: MYTHEME.RATING_GOOD # You can also translate the titles
      5: Awesome
```

#### Notes
* There is a .half css class that can be used to implement half-stars later on. I've not implemented this option yet, as that sounded more complex, than currently required. Also it was harder to click
* The code was inspired from: https://codepen.io/jamesbarnett/pen/vlpkh?editors=1100
* TODO: The css must be regenerated from the scss.
* TODO: Add changelog

#### Questions
* Is there a way to validate the value after submitting? If someone is passing something random like "bomb" instead of "5", this might still get through the formular. I am not sure how the slider for example handle such an issue. Maybe you can clarify
* Do you have a better idea of clearing the `float:left` style for the ratings?
