### PR TITLE
Translate form labels also in text file

### DIFF
--- a/templates/forms/default/data.txt.twig
+++ b/templates/forms/default/data.txt.twig
@@ -9,7 +9,7 @@
         {%- if show_field %}
             {%- set value = form.value(scope ~ (field.name ?? index)) -%}
             {%- if value -%}
-            {{- field.label }}: {{ string(value is iterable ? value|json_encode : value|e) ~ "\r\n" }}
+            {{- field.label|t|e }}: {{ string(value is iterable ? value|json_encode : value|e) ~ "\r\n" }}
             {%- endif -%}
         {%- endif %}
     {%- endif %}


### PR DESCRIPTION
Currently only done in html template.

Before:
```
PLUGIN_COMMENTS.NAME_LABEL: NicoHood
[...]
```

After:
```
Name: NicoHood
[...]
```

Useful when saving/logging form data to text file:
```yaml
        save:
            fileprefix: comments-
            dateformat: Ymd-His-u
            extension: txt
            body: "{% include 'forms/data.txt.twig' %}"
```