### PR TITLE
Fix has-errors for checkboxes and other fields

### DIFF
--- a/templates/forms/layouts/field.html.twig
+++ b/templates/forms/layouts/field.html.twig
@@ -1,5 +1,5 @@
 {% block field %}
-<div class="form-field {{ layout_form_field_outer_classes|trim -}} {{- form_field_outer_core|trim -}}">
+<div class="form-field {{ layout_form_field_outer_classes|trim }} {{ form_field_outer_core|trim}}">
   {% block contents %}
     {% if show_label %}
       <div class="{{- layout_form_field_outer_label_classes -}}">


### PR DESCRIPTION
```
my_field:
  type: checkboxes
  options:
    option1: Option 1
    option2: Option 2
    option3: Option 3
  label: "Test field"
  validate:
    required: true
```

Before:
```
class="form-field form-grouphas-errors"
```

After:
```
class="form-field form-group has-errors"
```

This bug made the checkboxes render wrong, as some important classes were missing, due to the whitespace bug. Twig also removes other whitespaces outside the tag when using `{-`. I think the `trim` filter is always a better option. I did not check, if there are other places that also need a fix.