### PR TITLE
Fix #453 section title level

### DIFF
--- a/templates/forms/fields/section/section.html.twig
+++ b/templates/forms/fields/section/section.html.twig
@@ -1,10 +1,11 @@
 {% extends "forms/field.html.twig" %}
+{% set title_level = grav.user.access.admin.login ? 'h1' : field.title_level|default('h3') %}
 
 {% block field %}
 {% if field.security is empty or authorize(array(field.security)) %}
 <div class="{{ field.classes }}">
     {% if field.title or field.underline %}
-    <h1 class="{% if not field.underline %}no_underline{% endif %}">{{ field.title|t }}</h1>
+    <{{ title_level }} class="{% if not field.underline %}no_underline{% endif %}">{{ field.title|t }}</{{ title_level }}>
     {% endif %}
 
     {% if field.text %}


### PR DESCRIPTION
Please note:
* `h1` is still used in admin panel
* `h3` is the new default for frontend forms
* Use `title_level` attribute to customize the section title level

If the PR gets merged, I will add documentation for that feature as well.