### PR TITLE
Fix checkboxes checked state

### DIFF
--- a/templates/forms/fields/checkboxes/checkboxes.html.twig
+++ b/templates/forms/fields/checkboxes/checkboxes.html.twig
@@ -18,7 +18,7 @@
         {% set id = field.id|default(field.name)|hyphenize ~ '-' ~ key %}
         {% set name = field.use == 'keys' ? key : id %}
         {% set val = field.use == 'keys' ? '1' : key %}
-        {% set checked = (field.use == 'keys' ? value[key] : key in value) %}
+        {% set checked = value[key] %}
         {% set help = (key in field.help_options|keys ? field.help_options[key] : false) %}
 
         <div class="checkboxes {{ form_field_wrapper_classes }} {{ field.wrapper_classes }}">


### PR DESCRIPTION
This is a long standing issue (7 years) for checkbox default values when `use: keys` is **not** used. The default values are still specified in a named array `defaultvalue => keyname` but the code assumes a flat array. When setting a default value of `false` the code will fail. You can test this using:

```yaml
my_field:
    type: checkboxes
    label: A couple of checkboxes
    default:
        option1: true
        option2: false
    options:
        option1: Option 1
        option2: Option 2
```


**Edit: It seems there is more broken. I will work on that and edit.**