### PR TITLE
Added evaluate option for all non-iterable field types and checkboxes

### DIFF
--- a/templates/forms/default/field.html.twig
+++ b/templates/forms/default/field.html.twig
@@ -7,7 +7,7 @@
 {% set vertical = field.style == 'vertical' %}
 
 {% if not blueprints or (blueprints.schema.type(field.type)['input@'] ?? true) is same as(true) %}
-    {% set default = field.default %}
+    {% set default = default ?? (field.evaluate and field.default and field.default is not iterable ? evaluate(field.default) : field.default) %}
     {% set toggleable = field.toggleable ?? false %}
     {% if toggleable %}
         {% set originalValue = originalValue is defined ? originalValue : value %}

--- a/templates/forms/fields/checkboxes/checkboxes.html.twig
+++ b/templates/forms/fields/checkboxes/checkboxes.html.twig
@@ -1,10 +1,19 @@
 {% extends "forms/field.html.twig" %}
 
 {% set originalValue = value %}
-{% set value = (value is null ? field.default : value) %}
-{% if field.use == 'keys' and field.default %}
-    {% set value = field.default|merge(value) %}
-{% endif %}
+
+{% set default = {} %}
+{% for key, default_value in field.default %}
+    {% set default_value = (default_value and field.evaluate) ? evaluate(default_value) : default_value %}
+    {% if default_value %}
+        {% if field.use == 'keys' %}
+            {# NOTE: The brackets around the key are important! #}
+            {% set default = default|merge({(key): default_value} ) %}
+        {% else %}
+            {% set default = default|merge([default_value]) %}
+        {% endif %}
+    {% endif %}
+{% endfor %}
 
 {% block global_attributes %}
     {{ parent() }}

--- a/templates/forms/fields/hidden/hidden.html.twig
+++ b/templates/forms/fields/hidden/hidden.html.twig
@@ -2,7 +2,6 @@
 
 {% block field %}
 
-{% set value = value ?: (field.value ?? (field.evaluate ? evaluate(field.default) : field.default)) %}
 {% set input_value = value is iterable ? value|join(',') : value|string %}
 
 <input data-grav-field="hidden" data-grav-disabled="false" type="hidden" class="input" name="{{ (scope ~ field.name)|fieldName }}" value="{{ input_value|e('html_attr') }}" />


### PR DESCRIPTION
This PR adds the option to `evaluate` all kind of field default values. Currently every string based field and checkboxes are supported. This is very helpful to prefill forms based on query strings for example. This PR is safe against XSS, as only the default value gets evaluated. The evaluation function should be written with care, as always.

Examples:
```yaml
name:
    label: Title
    placeholder: 'Enter the new title'
    type: text
    evaluate: true
    default: 'page.title'
    validate:
        required: true

my_field:
    type: checkboxes
    label: A couple of checkboxes
    evaluate: true
    default:
        - "uri.query('happy') is same as('true') ? 'option2'"
    options:
        option1: Option 1
        option2: Option 2

my_field_keys:
    type: checkboxes
    label: A couple of checkboxes
    evaluate: true
    default:
        option1: `uri.query('happy') is same as('true')`
    options:
        option1: Option 1
        option2: Option 2
```


This PR needs a rebase after https://github.com/getgrav/grav-plugin-form/pull/472 is merged. I will take care of that then.