### PR TITLE
Always use lower case in email field

### DIFF
--- a/classes/Form.php
+++ b/classes/Form.php
@@ -841,6 +841,9 @@ class Form implements FormInterface, \ArrayAccess
                 if ($field['type'] === 'checkbox' || $field['type'] === 'switch') {
                     $data[$name] = isset($data[$name]) ? true : false;
                 }
+                if ($field['type'] === 'email' && isset($data[$name])) {
+                    $data[$name] = strtolower($data[$name]);
+                }
                 $i++;
             }
 

--- a/templates/forms/fields/email/email.html.twig
+++ b/templates/forms/fields/email/email.html.twig
@@ -1,10 +1,26 @@
 {% extends "forms/field.html.twig" %}
 
-{% block input_attributes %}
-    type="email"
-    {% if field.multiple in ['on', 'true', 1] %}multiple="multiple"{% endif %}
-    {% if field.size %}size="{{ field.size }}"{% endif %}
-    {% if field.minlength is defined or field.validate.min is defined %}minlength="{{ field.minlength | default(field.validate.min) }}"{% endif %}
-    {% if field.maxlength is defined or field.validate.max is defined %}maxlength="{{ field.maxlength | default(field.validate.max) }}"{% endif %}
-    {{ parent() }}
+{% block input %}
+  <div class="{{ layout_form_field_wrapper_classes }} {{ field.size }}">
+    {% block prepend %}{% endblock prepend %}
+    {% set input_value = value is iterable ? value|join(',') : value|string %}
+    <input
+      name="{{ (scope ~ field.name)|fieldName }}"
+      value="{{ input_value|lower|e }}"
+      {% block input_attributes %}
+          type="email"
+          {% if field.multiple in ['on', 'true', 1] %}multiple="multiple"{% endif %}
+          {% if field.size %}size="{{ field.size }}"{% endif %}
+          {% if field.minlength is defined or field.validate.min is defined %}minlength="{{ field.minlength | default(field.validate.min) }}"{% endif %}
+          {% if field.maxlength is defined or field.validate.max is defined %}maxlength="{{ field.maxlength | default(field.validate.max) }}"{% endif %}
+          {{ parent() }}
+      {% endblock %}
+    />
+    {% block append %}{% endblock append %}
+    {% if inline_errors and errors %}
+    <div class="{{ form_field_inline_error_classes }}">
+      <p class="form-message"><i class="fa fa-exclamation-circle"></i> {{ errors|first|raw }}</p>
+    </div>
+    {% endif %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
Always parse email field in lower case to avoid duplicated emails with mixed case in further processing. For example someone could subscribe for a newsletter, add a comment or rating using the same email multiple times:
* test@test.com
* TEST@test.com
* TEst@test.com

I've fixed the issue in the post processing (important), but also in the twig template. For example when someone enters an upper case default value or the string is processed via twig (in case my other PR gets merged).