### PR TITLE
do not execute form action captcha, ip and timestamp if value is false

### DIFF
--- a/classes/Form.php
+++ b/classes/Form.php
@@ -915,6 +915,11 @@ class Form implements FormInterface, ArrayAccess
                     $data = $data[$action];
                 }
 
+                // do not execute action, if deactivated
+                if (Utils::isNegative($data)) {
+                    continue;
+                }
+
                 $event = new Event(['form' => $this, 'action' => $action, 'params' => $data]);
                 $grav->fireEvent('onFormProcessed', $event);
 

--- a/classes/Form.php
+++ b/classes/Form.php
@@ -916,7 +916,7 @@ class Form implements FormInterface, ArrayAccess
                 }
 
                 // do not execute action, if deactivated
-                if (Utils::isNegative($data)) {
+                if (in_array($data, [false, 'false'], true)) {
                     continue;
                 }
 

--- a/form.php
+++ b/form.php
@@ -414,6 +414,9 @@ class FormPlugin extends Plugin
 
         switch ($action) {
             case 'captcha':
+                if (Utils::isNegative($params)) {
+                    break;
+                }
 
                 $captcha_config = $this->config->get('plugins.form.recaptcha');
 
@@ -475,6 +478,10 @@ class FormPlugin extends Plugin
                 }
                 break;
             case 'timestamp':
+                if (Utils::isNegative($params)) {
+                    break;
+                }
+
                 $label = $params['label'] ?? 'Timestamp';
                 $format = $params['format'] ?? 'Y-m-d H:i:s';
                 $blueprint = $form->value()->blueprints();
@@ -485,6 +492,10 @@ class FormPlugin extends Plugin
                 $form->setData('timestamp', $date_string);
                 break;
             case 'ip':
+                if (Utils::isNegative($params)) {
+                    break;
+                }
+
                 $label = $params['label'] ?? 'User IP';
                 $blueprint = $form->value()->blueprints();
                 $blueprint->set('form/fields/ip', ['name' => 'ip', 'label' => $label, 'type' => 'hidden']);

--- a/form.php
+++ b/form.php
@@ -414,10 +414,6 @@ class FormPlugin extends Plugin
 
         switch ($action) {
             case 'captcha':
-                if (Utils::isNegative($params)) {
-                    break;
-                }
-
                 $captcha_config = $this->config->get('plugins.form.recaptcha');
 
                 $secret = $params['recaptcha_secret'] ?? $params['recatpcha_secret'] ?? $captcha_config['secret_key'];
@@ -478,10 +474,6 @@ class FormPlugin extends Plugin
                 }
                 break;
             case 'timestamp':
-                if (Utils::isNegative($params)) {
-                    break;
-                }
-
                 $label = $params['label'] ?? 'Timestamp';
                 $format = $params['format'] ?? 'Y-m-d H:i:s';
                 $blueprint = $form->value()->blueprints();
@@ -492,10 +484,6 @@ class FormPlugin extends Plugin
                 $form->setData('timestamp', $date_string);
                 break;
             case 'ip':
-                if (Utils::isNegative($params)) {
-                    break;
-                }
-
                 $label = $params['label'] ?? 'User IP';
                 $blueprint = $form->value()->blueprints();
                 $blueprint->set('form/fields/ip', ['name' => 'ip', 'label' => $label, 'type' => 'hidden']);

--- a/form.php
+++ b/form.php
@@ -414,6 +414,7 @@ class FormPlugin extends Plugin
 
         switch ($action) {
             case 'captcha':
+
                 $captcha_config = $this->config->get('plugins.form.recaptcha');
 
                 $secret = $params['recaptcha_secret'] ?? $params['recatpcha_secret'] ?? $captcha_config['secret_key'];


### PR DESCRIPTION
You can define form process actions like this:
```
process:
  captcha: true
  ip: true
  timestamp: true
```

But reversing this, so lets say set `captcha: false` will still try to validate the captcha.

I have added checks to these 3 process actions to check if they should be executed.
Maybe we should also consider to make this a general rule for all actions?