### PR TITLE
Fix missing forms issue after redirect

### DIFF
--- a/form.php
+++ b/form.php
@@ -792,10 +792,11 @@ class FormPlugin extends Plugin
                 return $first_form;
             }
 
-            //No form on this route. Try looking up in the current page first
-            /** @var Forms $forms */
-            $forms = $this->grav['forms'];
-            return $forms->createPageForm($this->grav['page']);
+            // Try to get page by defined route first or get current if not found
+            $page = $this->grav['pages']->find($page_route) ?: $this->grav['page'];
+
+            // Try looking up in the defined page
+            return $this->grav['forms']->createPageForm($page);
         }
 
         // return the form you are looking for if available


### PR DESCRIPTION
This PR makes forms try to find page by given route first instead of falling back to current page right away.
This fixes [missing forms issue described here](https://github.com/getgrav/grav/issues/3180), when form is included as a widget.

**NB:** This PR doesn't fix issue where `$this->forms` is empty and form still can't be found by name. This fixes only if form is searched by page route. Eg. `forms({'route':'my-page/route'})` while you're on another page