### PR TITLE
Add `id` attribute to hidden field

### DIFF
--- a/templates/forms/fields/hidden/hidden.html.twig
+++ b/templates/forms/fields/hidden/hidden.html.twig
@@ -11,5 +11,5 @@
 {% endif %}
 {% set input_value = value is iterable ? value|join(',') : value|string %}
 
-<input data-grav-field="hidden" data-grav-disabled="false" type="hidden" class="input" name="{{ (scope ~ field.name)|fieldName }}" value="{{ input_value|e('html_attr') }}" />
+<input data-grav-field="hidden" data-grav-disabled="false" {% if field.id is defined %}id="{{ field.id|e }}" {% endif %}type="hidden" class="input" name="{{ (scope ~ field.name)|fieldName }}" value="{{ input_value|e('html_attr') }}" />
 {% endblock %}


### PR DESCRIPTION
It comes in handy if you want to do any value manipulation to it on AJAX submit. So to not search for element by `name` attribute, ID is very useful