### PR TITLE
Toggle fields do not save `false` if they are `toggleable` [#497]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 ## mm/dd/2021
 
 1. [](#new)
+   * Requires **Grav 1.7.0**
    * Allow admins to temporarily disable form process actions by setting the value to `false` [#481](https://github.com/getgrav/grav-plugin-form/pull/481)
 1. [](#bugfix)
    * Fixed reCaptcha v3 incompatibility with multiple forms on the same page sharing different actions [#416](https://github.com/getgrav/grav-plugin-form/issues/416)
+   * Toggle fields do not save `false` if they are `toggleable` [#497](https://github.com/getgrav/grav-plugin-form/issues/497)
 
 # v4.3.1
 ## 01/31/2021

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -15,7 +15,7 @@ bugs: https://github.com/getgrav/grav-plugin-form/issues
 license: MIT
 
 dependencies:
-  - { name: grav, version: '>=1.6.0' }
+  - { name: grav, version: '>=1.7.0' }
 
 form:
   validation: strict

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "docs": "https://github.com/getgrav/grav-plugin-form/blob/master/README.md"
   },
   "require": {
-    "php": ">=7.1.3",
+    "php": "^7.3.6 || ^8.0",
     "ext-json": "*",
     "google/recaptcha": "^1.2"
   },
@@ -34,7 +34,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.1.3"
+      "php": "7.3.6"
     }
   }
 }

--- a/templates/forms/fields/toggle/toggle.html.twig
+++ b/templates/forms/fields/toggle/toggle.html.twig
@@ -38,7 +38,7 @@
              id="{{ id }}"
              name="{{ (scope ~ field.name)|fieldName }}"
           {% if field.highlight is defined %}
-            class="{{ field.highlight|string same as(key) ? 'highlight' : '' }}"
+            class="{{ field.highlight|string is same as(key) ? 'highlight' : '' }}"
           {% endif %}
           {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}
           {% if key is same as(value) %}

--- a/templates/forms/fields/toggle/toggle.html.twig
+++ b/templates/forms/fields/toggle/toggle.html.twig
@@ -20,13 +20,6 @@
 {% endblock %}
 
 {% block input %}
-    {% set value = (value is same as(false) ? 0 : value) %}
-
-    {% if field.force_bool and get_type(value) == 'string'%}
-        {% set value = true %}
-    {% endif %}
-
-
   <div class="switch-toggle switch-grav {{ field.size }} switch-{{ field.options|length }} {{ field.classes }}">
     {% set maxLen = 0 %}
     {% for text in field.options %}
@@ -34,7 +27,9 @@
       {% set maxLen = max(translation|length, maxLen) %}
     {% endfor %}
 
+    {% set value = value|string %}
     {% for key, text in field.options %}
+      {% set key = key|string %}
       {% set id = "toggle_" ~ field.name ~ key %}
       {% set translation = text|t|trim %}
 
@@ -43,19 +38,11 @@
              id="{{ id }}"
              name="{{ (scope ~ field.name)|fieldName }}"
           {% if field.highlight is defined %}
-            class="{{ field.highlight == '' ~ key ? 'highlight' : '' }}"
+            class="{{ field.highlight|string same as(key) ? 'highlight' : '' }}"
           {% endif %}
           {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}
-          {% if field.toggleable %}
-            {% if '' ~ key == '' ~ value %}
-              checked="checked"
-            {% elseif value is defined and (key == 1 or key == '1') %}
-              checked="checked"
-            {% endif %}
-          {% else %}
-            {% if '' ~ key == '' ~ value %}
-              checked="checked"
-            {% endif %}
+          {% if key is same as(value) %}
+            checked="checked"
           {% endif %}
           {% if required %}required="required"{% endif %}
           {% if field.tabindex %}tabindex="{{ field.tabindex }}"{% endif %}


### PR DESCRIPTION
This change fixes #497 and simplifies the logic, but also requires Grav 1.7 in order to work (`|string` filter was made to work with boolean `false`).

It is possible to make this fix also in Grav 1.6 compatible way, but it gets a bit complicated.