### PR TITLE
render markdown in `data.html.twig` template

### DIFF
--- a/templates/forms/default/data.html.twig
+++ b/templates/forms/default/data.html.twig
@@ -13,7 +13,13 @@
                     {% block field %}
                         <div>
                             {% block field_label %}
-                                <strong>{{ field.label|t|e }}</strong>:
+                                <strong>
+                                    {%- if field.markdown -%}
+                                        {{ field.label|t|markdown(false) }}
+                                    {%- else -%}
+                                        {{ field.label|t|e }}
+                                    {%- endif -%}
+                                </strong>:
                             {% endblock %}
 
                             {% block field_value %}


### PR DESCRIPTION
When using markdown in a fields label it is not rendered in eg. emails, even though its activated through `markdown: true`.