### PR TITLE
Updating the display field to allow dynamic input

### DIFF
--- a/templates/forms/fields/display/display.html.twig
+++ b/templates/forms/fields/display/display.html.twig
@@ -1,5 +1,5 @@
 {% extends "forms/field.html.twig" %}
-
+ 
 {% if field.file %}
     {% set content = read_file(field.file) %}
 {% else %}
@@ -11,7 +11,11 @@
         {% if field.markdown %}
             {{ content|t|markdown|raw }}
         {% else %}
-            {{ content|t|raw }}
+            {% if field.evaluate %}
+              {{ evaluate_twig(content)|raw }}
+            {% else %}
+              {{ content|t|raw }}
+            {% endif %}
         {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
This change will allow users to insert dynamically created contents inline on their forms. With this change, users can add something like this to their frontmatter on their fields within their pages:
```
content: '{{ page.content|raw }}'
evaluate: true
```
This PR doesn't include doc changes. :(