### PR TITLE
Add conditional for label that ends up blank for checkboxes

### DIFF
--- a/templates/forms/layouts/field/default-field.html.twig
+++ b/templates/forms/layouts/field/default-field.html.twig
@@ -1,7 +1,7 @@
 {% block field %}
 <div class="form-field {{ layout_form_field_outer_classes|trim }} {{ form_field_outer_core|trim}}">
   {% block contents %}
-    {% if show_label %}
+    {% if show_label and field.type != 'checkbox' %}
       <div class="{{- layout_form_field_outer_label_classes -}}">
         {{- form_field_toggleable -}}
         <label class="{{ layout_form_field_label_classes }}{{ form_field_label_trim }}" {% if field.id %}for="{{ form_field_for }}"{% endif %}>


### PR DESCRIPTION
Without this conditional, checkboxes render a blank label

`<div class="form-label"><label class="inline"></label></div>`

Having the blank label screws with accessibility.

Sure, you can manually set each checkbox to `display_label: false` but that in itself is confusing since removes the broken label and keeps the checkbox label. Since the default checkbox no matter what creates a blank div and label, the best way around this is to just add this conditional