### PR TITLE
Add reCaptcha theme to element via data attribute

### DIFF
--- a/templates/forms/fields/captcha/captcha.html.twig
+++ b/templates/forms/fields/captcha/captcha.html.twig
@@ -95,6 +95,6 @@
     </script>
     <script src="https://www.google.com/recaptcha/api.js?onload=captchaOnloadCallback_{{ formName }}&render=explicit&hl={{ grav.language.language }}&theme={{ theme }} "
         async defer></script>
-    <div class="g-recaptcha" id="g-recaptcha-{{ formName }}"></div>
+    <div class="g-recaptcha" id="g-recaptcha-{{ formName }}" data-theme="{{ theme }}"></div>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
Just `&theme={{ theme }}` in script URL does not work. Adding `data-theme="{{ theme }}"` to element itself does the trick.
Also [this is documented in Google reCaptcha docs](https://developers.google.com/recaptcha/docs/display#render_param)