### PR TITLE
Add hCaptcha support

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -170,6 +170,14 @@ form:
       title: PLUGIN_FORM.RECAPTCHA
 
       fields:
+        recaptcha.provider:
+          type: select
+          label: PLUGIN_FORM.RECAPTCHA_PROVIDER
+          help: PLUGIN_FORM.RECAPTCHA_PROVIDER_HELP
+          default: reCaptcha
+          options:
+            reCaptcha: reCaptcha (Google)
+            hCaptcha: hCaptcha (Intuition Machines)
         recaptcha.version:
           type: select
           label: PLUGIN_FORM.RECAPTCHA_VERSION
@@ -189,10 +197,8 @@ form:
         recaptcha.site_key:
           type: text
           label: PLUGIN_FORM.RECAPTCHA_SITE_KEY
-          help: PLUGIN_FORM.RECAPTCHA_SITE_KEY_HELP
           default: ''
         recaptcha.secret_key:
           type: text
           label: PLUGIN_FORM.RECAPTCHA_SECRET_KEY
-          help: PLUGIN_FORM.RECAPTCHA_SECRET_KEY_HELP
           default: ''

--- a/languages.yaml
+++ b/languages.yaml
@@ -14,6 +14,8 @@ en:
     DATA_SUMMARY: "Here is the summary of what you wrote to us:"
     NO_FORM_DATA: "No form data available"
     RECAPTCHA: "reCAPTCHA"
+    RECAPTCHA_PROVIDER: "Captcha Provider"
+    RECAPTCHA_PROVIDER_HELP: "reCaptcha (Google): For more info visit https://developers.google.com/recaptcha\nhCaptcha (Intuition Machines): For more info visit https://docs.hcaptcha.com"
     RECAPTCHA_VERSION: "Version"
     RECAPTCHA_VERSION_V2_CHECKBOX: "v2 - Checkbox"
     RECAPTCHA_VERSION_V2_INVISIBLE: "v2 - Invisible"

--- a/templates/forms/fields/captcha/captcha.html.twig
+++ b/templates/forms/fields/captcha/captcha.html.twig
@@ -5,6 +5,8 @@
 {% set action = (page.route|trim('/') ~ '-' ~ form.name)|underscorize %}
 {% set formName = form.name|underscorize %}
 {% set theme = config.plugins.form.recaptcha.theme ?? 'light' %}
+{% set _captchaURL = config.plugins.form.recaptcha.provider == 'hCaptcha' ? 'https://js.hcaptcha.com/1/api.js' : 'https://www.google.com/recaptcha/api.js' %}
+{% set _captchaName = config.plugins.form.recaptcha.provider == 'hCaptcha' ? 'h-captcha' : 'g-recaptcha' %}
 
 {% block label %}{% endblock %}
 
@@ -12,7 +14,7 @@
   {% if not site_key %}
       <script type="application/javascript">console && console.error('site_key was not defined for form "{{ form.name }}" (Grav Form Plugin)')</script>
   {% elseif config.plugins.form.recaptcha.version == 3 %}
-      {% do assets.addJs('https://www.google.com/recaptcha/api.js?render='~site_key~'&theme=' ~ theme) %}
+      {% do assets.addJs(_captchaURL ~ '?render=' ~ site_key ~ '&theme=' ~ theme) %}
       {#<script src='https://www.google.com/recaptcha/api.js?render={{ site_key }}&theme={{ theme }}'></script>#}
       <script type="application/javascript">
           window.gRecaptchaInstances = window.gRecaptchaInstances || {};
@@ -53,17 +55,17 @@
               submits.forEach(function(submit) {
                   submit.addEventListener('click', function(event) {
                       event.preventDefault();
-                      var captchaElement = form.querySelector('#g-recaptcha-{{ formName }}');
+                      var captchaElement = form.querySelector('#{{ _captchaName }}-{{ formName }}');
 
                       if (captchaElement) {
                           captchaElement.remove();
                       }
 
                       captchaElement = document.createElement('div');
-                      captchaElement.setAttribute('id', 'g-recaptcha-{{ formName }}');
+                      captchaElement.setAttribute('id', '{{ _captchaName }}-{{ formName }}');
                       form.appendChild(captchaElement);
 
-                      var widgetReference = grecaptcha.render('g-recaptcha-{{ formName }}', {
+                      var widgetReference = grecaptcha.render('{{ _captchaName }}-{{ formName }}', {
                           sitekey: '{{ site_key }}', size: 'invisible',
                           callback: function(/* token */) {
                               form.submit();
@@ -76,12 +78,12 @@
           }
       </script>
 
-      <script src="https://www.google.com/recaptcha/api.js?onload=captchaOnloadCallback_{{ formName }}&hl={{ grav.language.language }}&theme={{ theme }}"
+      <script src="{{ _captchaURL }}?onload=captchaOnloadCallback_{{ formName }}&hl={{ grav.language.language }}&theme={{ theme }}"
               async defer></script>
   {% else %}
     <script type="application/javascript">
         var captchaOnloadCallback_{{ formName }} = function captchaOnloadCallback_{{ formName }}() {
-            grecaptcha.render('g-recaptcha-{{ formName }}', {
+            grecaptcha.render('{{ _captchaName }}-{{ formName }}', {
                 'sitekey': "{{ site_key }}",
                 'callback': captchaValidatedCallback_{{ formName }},
                 'expired-callback': captchaExpiredCallback_{{ formName }}
@@ -93,8 +95,8 @@
             grecaptcha.reset();
         };
     </script>
-    <script src="https://www.google.com/recaptcha/api.js?onload=captchaOnloadCallback_{{ formName }}&render=explicit&hl={{ grav.language.language }}&theme={{ theme }} "
+    <script src="{{ _captchaURL }}?onload=captchaOnloadCallback_{{ formName }}&render=explicit&hl={{ grav.language.language }}&theme={{ theme }} "
         async defer></script>
-    <div class="g-recaptcha" id="g-recaptcha-{{ formName }}" data-theme="{{ theme }}"></div>
+    <div class="{{ _captchaName }}" id="{{ _captchaName }}-{{ formName }}" data-theme="{{ theme }}"></div>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
This will add hCaptcha support.

- The user only needs to select the provider: reCaptcha or hCaptcha.

👉 PHP code on server side could (should) be optimized.

Tested to be working.
- reCaptcha (Google) works as before and is the default behaviour.
- hCaptcha has been tested for v2-checkbox and works.
- No error cases were tested for hCaptcha, so unknown behaviour in such cases.

Fixes #423.
Replaces #515.

Kind regards.