### PR TITLE
Correct action for deep modular page #571

### DIFF
--- a/templates/forms/fields/captcha/captcha.html.twig
+++ b/templates/forms/fields/captcha/captcha.html.twig
@@ -2,7 +2,7 @@
 
 {% set config = grav.config %}
 {% set site_key = field.recaptcha_site_key and field.recaptcha_site_key != 'ENTER_YOUR_CAPTCHA_SITE_KEY' ? field.recaptcha_site_key : config.plugins.form.recaptcha.site_key %}
-{% set action = (page.route|trim('/') ~ '-' ~ form.name)|underscorize %}
+{% set action = (page.route|trim('/') ~ '-' ~ form.name)|underscorize|md5 %}
 {% set formName = form.name|underscorize %}
 {% set theme = config.plugins.form.recaptcha.theme ?? 'light' %}
 


### PR DESCRIPTION
When you put a form with recaptcha v3 in a modular deep in pages, Google return an error.

Changed the action path to a md5 which is shorter and respects Google's requirements