### PR TITLE
Added `title_type` field to allow users to choose the header tag  and improve styling

### DIFF
--- a/templates/forms/fields/spacer/spacer.html.twig
+++ b/templates/forms/fields/spacer/spacer.html.twig
@@ -1,9 +1,9 @@
 {% extends "forms/field.html.twig" %}
 
 {% block field %}
-<div class="form-spacer {{ field.classes }}">
+<div class="form-field form-spacer {{ field.classes }}">
     {% if field.title %}
-        <h3>{{- field.title|t|raw -}}</h3>
+        <{{ title_type|default('h3') }}>{{- field.title|t|raw -}}</ {{ title_type|default('h3') }}>
     {% endif %}
 
     {% if field.markdown %}


### PR DESCRIPTION
- Added `title_type` field to allow users to choose the header tag (h1, h2, h3, etc.).
- Defaults to `h3` if `title_type` is not specified.
- Added `form-field` class to the spacer div for consistent margins with other fields.