### PR TITLE
Allow form resubmit on validation error.

### DIFF
--- a/form.php
+++ b/form.php
@@ -1154,7 +1154,9 @@ class FormPlugin extends Plugin
 
             if ($form) {
                 // Only set posted unique id if the form name matches to the one that was posted.
-                if ($unique_id && $form_name === $form->getFormName()) {
+                // And only if it was a successful form submit, if the validation catches an error
+                // the user need to be able to correct that.
+                if ($unique_id && $form_name === $form->getFormName() && $form->validate()) {
                     $form->setUniqueId($unique_id);
                     $form->initialize();
                 }


### PR DESCRIPTION
Problem: If the `plugins.form.refresh_prevention` setting is set the form will reset the same _unique_ id, and thus find out if it is a secondary submit.
If the form has fields that need to be validated, and the validation returns errors, this very same _unique_ id prevents the user to resend the form with corrected data.

So this change checks, if the validation has indeed flagged the form as invalid and if so does **not** overwrite the already newly generated _unique_ id. Thus allowing to resubmit the form on validation errors.