### PR TITLE
Add data.yaml.twig handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v8.x.x
+## __/__/____
+1. [](#improved)
+    - Add `data.yaml.twig` handler for the form save action to write the data as valid yaml
+
 # v8.2.1
 ## 12/28/2025
 

--- a/templates/forms/data.yaml.twig
+++ b/templates/forms/data.yaml.twig
@@ -1,0 +1,1 @@
+{% extends "forms/default/data.yaml.twig" %}

--- a/templates/forms/default/data.yaml.twig
+++ b/templates/forms/default/data.yaml.twig
@@ -1,0 +1,23 @@
+{%- macro render_field(form, fields, scope) %}
+{%- import _self as self %}
+{%- autoescape false %}
+{%- for index, field in fields %}
+    {%- set show_field = attribute(field, "input@") ?? field.store ?? true %}
+    {%- if field.fields %}
+        {%- set new_scope = field.nest_id ? scope ~ field.name ~ '.' : scope -%}
+        {{- self.render_field(form, field.fields, new_scope) }}
+    {%- else %}
+        {%- if show_field %}
+            {%- set value = form.value(scope ~ (field.name ?? index)) -%}
+            {%- if value -%}
+            {{- (field.data_label ? field.data_label|t|e : field.label|t|e)|yaml_encode }}: {{ string(value is iterable ? value|json_encode : value)|yaml_encode ~ "\n" }}
+            {%- endif -%}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- endautoescape %}
+{%- endmacro %}
+{%- import _self as macro %}
+{%- autoescape false %}
+{{- macro.render_field(form, form.fields, '') ~ "\n" }}
+{%- endautoescape %}


### PR DESCRIPTION
The `data.txt.twig` handler does not care about linebreaks, but yaml does. So I added a new one and made the adjustments to properly write the data.