### PR TITLE
Fixed typo in date for v9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
    * [security] Fixed stored XSS in select-field option text (GHSA-c2q3-p4jr-c55f). Removed the `|raw` filter from `templates/forms/fields/select/select.html.twig`; option labels — including taxonomy values that propagate cross-page through the admin's shared selection pool — are now autoescaped, so a lower-privileged editor can no longer inject script that runs in an admin's browser when they open any page editor.
 
 # v9.0.0
-## 04/21/20265
+## 04/21/2026
 
 1. [](#new)
     * Added new open source Cap.js powered Proof of Work (POW) captcha option, local PHP-based server, so no 3rd party services required, and 'invisible', no checkboxes or visual interaction required.


### PR DESCRIPTION
Caused an exception when trying to view the changelog from de Grav admin

```
grav.CRITICAL: An exception has been thrown during the rendering of a template ("Failed to parse time string (04/21/20265) at position 10 (5): Unexpected character")
```